### PR TITLE
Add music_info analysis notebook with cleaning and preprocessing Closes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,27 @@ Dataset musicale contenente:
 - utenti 
 - cronologia ascolti 
 
+## Preprocessing e Data Analysis
+
+Prima dell’ingestione in MongoDB, i dataset sono stati analizzati e validati tramite notebook dedicati.
+
+In particolare:
+- **music_info**: operazioni di data cleaning e gestione dei valori mancanti (in particolare sulla variabile `genre`)
+- **listening_history**: analisi esplorativa e verifica della qualità dei dati
+
+Le principali attività svolte includono:
+- analisi della struttura dei dataset (colonne, dimensioni, tipi di dato)
+- verifica di valori nulli, duplicati e inconsistenze
+- studio delle distribuzioni (es. `playcount`, con evidenza di long tail)
+- validazione delle chiavi logiche (es. `user_id` + `track_id`)
+
+I risultati hanno evidenziato dataset complessivamente consistenti e pronti per l’utilizzo, con interventi minimi di preprocessing.
+
+I dataset risultanti vengono quindi utilizzati come base per:
+- l’ingestione in MongoDB
+- la progettazione delle collezioni
+- le query e analisi successive
+
 ## Requisiti
 - Python 3.12
 - MongoDB 8.0

--- a/notebooks/data_analysis&pre-processing_ListeningHistory.ipynb
+++ b/notebooks/data_analysis&pre-processing_ListeningHistory.ipynb
@@ -1,0 +1,1189 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e681fa3d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005714,
+     "end_time": "2026-04-11T16:02:15.715779+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:15.710065+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Analisi e validazione del dataset `User Listening History`\n",
+    "\n",
+    "Questo notebook documenta l’analisi esplorativa e gli interventi di pulizia effettuati sul dataset `User Listening History.csv`, utilizzato come base per la modellazione delle collection `listeners` e `listening_history` nel progetto MongoDB.\n",
+    "\n",
+    "L'obiettivo dell'analisi è:\n",
+    "- esplorare la struttura del dataset `listening_history`\n",
+    "- verificare qualità e coerenza dei dati\n",
+    "- individuare anomalie, nulli, duplicati e colonne da trattare\n",
+    "- preparare un dataset pulito e coerente da usare nelle fasi successive del progetto\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "547614c9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004435,
+     "end_time": "2026-04-11T16:02:15.725027+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:15.720592+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Caricamento del dataset\n",
+    "\n",
+    "In questa sezione viene caricato il file `User Listening History.csv` e viene effettuata una prima ispezione della struttura generale del dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "12fcfa58",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T16:02:15.736043Z",
+     "iopub.status.busy": "2026-04-11T16:02:15.735653Z",
+     "iopub.status.idle": "2026-04-11T16:02:27.985491Z",
+     "shell.execute_reply": "2026-04-11T16:02:27.984366Z"
+    },
+    "papermill": {
+     "duration": 12.257962,
+     "end_time": "2026-04-11T16:02:27.987569+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:15.729607+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>track_id</th>\n",
+       "      <th>user_id</th>\n",
+       "      <th>playcount</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>TRIRLYL128F42539D1</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>TRFUPBA128F934F7E1</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>TRLQPQJ128F42AA94F</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>TRTUCUY128F92E1D24</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>TRHDDQG12903CB53EE</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>TRGRDEC128F423C07D</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>TRRYCBO128F932A2C7</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>TRUTULC128F4293712</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>TRAAHSY128F147BB5C</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>TRDLMWP128F426BF6C</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>TRMSZXT128F92F7816</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>TRVODUZ128F934D094</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>TRLXSNR128F429361D</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>TRPUGUW128F426BF6F</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>TRAUCNU128F42671EB</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>TRVVWSW128F4292931</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>TRADVZX128F426BF79</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>TRDCZUX128F4263A74</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>TRUYKTB128F1459197</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>TRQLOHS128F42435AE</td>\n",
+       "      <td>b80344d063b5ccb3212f76538f3d9e43d87dca9e</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              track_id                                   user_id  playcount\n",
+       "0   TRIRLYL128F42539D1  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "1   TRFUPBA128F934F7E1  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "2   TRLQPQJ128F42AA94F  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "3   TRTUCUY128F92E1D24  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "4   TRHDDQG12903CB53EE  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "5   TRGRDEC128F423C07D  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "6   TRRYCBO128F932A2C7  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "7   TRUTULC128F4293712  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "8   TRAAHSY128F147BB5C  b80344d063b5ccb3212f76538f3d9e43d87dca9e          2\n",
+       "9   TRDLMWP128F426BF6C  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "10  TRMSZXT128F92F7816  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "11  TRVODUZ128F934D094  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "12  TRLXSNR128F429361D  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "13  TRPUGUW128F426BF6F  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "14  TRAUCNU128F42671EB  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "15  TRVVWSW128F4292931  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "16  TRADVZX128F426BF79  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "17  TRDCZUX128F4263A74  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "18  TRUYKTB128F1459197  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1\n",
+       "19  TRQLOHS128F42435AE  b80344d063b5ccb3212f76538f3d9e43d87dca9e          1"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "DATA_PATH = \"/kaggle/input/datasets/undefinenull/million-song-dataset-spotify-lastfm/User Listening History.csv\" #sostuire con il proprio path locale del dataset\n",
+    "\n",
+    "df_hist = pd.read_csv(DATA_PATH)\n",
+    "df_hist.head(20)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7b6f742",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004921,
+     "end_time": "2026-04-11T16:02:27.997523+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:27.992602+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Panoramica del dataset\n",
+    "\n",
+    "Si analizzano dimensione, colonne e tipi logici dei dati, così da ottenere una visione iniziale delle informazioni disponibili e dei campi rilevanti per il progetto."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "df087d9f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T16:02:28.008581Z",
+     "iopub.status.busy": "2026-04-11T16:02:28.008249Z",
+     "iopub.status.idle": "2026-04-11T16:02:28.028591Z",
+     "shell.execute_reply": "2026-04-11T16:02:28.027292Z"
+    },
+    "papermill": {
+     "duration": 0.028401,
+     "end_time": "2026-04-11T16:02:28.030686+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:28.002285+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dimensione dataset: (9711301, 3)\n",
+      "Colonne dataset : ['track_id', 'user_id', 'playcount']\n",
+      "---------Info dataset------\n",
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 9711301 entries, 0 to 9711300\n",
+      "Data columns (total 3 columns):\n",
+      " #   Column     Dtype \n",
+      "---  ------     ----- \n",
+      " 0   track_id   object\n",
+      " 1   user_id    object\n",
+      " 2   playcount  int64 \n",
+      "dtypes: int64(1), object(2)\n",
+      "memory usage: 222.3+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Dimensione dataset: {df_hist.shape}\")\n",
+    "print(f\"Colonne dataset : {df_hist.columns.tolist()}\")\n",
+    "print(\"---------Info dataset------\")\n",
+    "df_hist.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fbdeeec7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004835,
+     "end_time": "2026-04-11T16:02:28.040658+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:28.035823+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Osservazioni iniziali\n",
+    "\n",
+    "- Il dataset contiene ~970k record\n",
+    "- Le colonne principali sono:\n",
+    "  - track_id\n",
+    "  - user_id\n",
+    "  - playcount\n",
+    "- I tipi di dato risultano coerenti (object per ID, int per playcount)\n",
+    "\n",
+    "Il dataset sembra rappresentare una relazione utente-traccia con numero di ascolti aggregati."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7f5192a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004694,
+     "end_time": "2026-04-11T16:02:28.050251+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:28.045557+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Analisi esplorativa iniziale\n",
+    "\n",
+    "In questa sezione vengono analizzate alcune metriche di base del dataset per comprendere:\n",
+    "- numero di utenti unici\n",
+    "- numero di tracce uniche\n",
+    "- distribuzione del numero di ascolti (`playcount`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f8faeab2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T16:02:28.062281Z",
+     "iopub.status.busy": "2026-04-11T16:02:28.061318Z",
+     "iopub.status.idle": "2026-04-11T16:02:30.877673Z",
+     "shell.execute_reply": "2026-04-11T16:02:30.876586Z"
+    },
+    "papermill": {
+     "duration": 2.824572,
+     "end_time": "2026-04-11T16:02:30.879700+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:28.055128+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Numero utenti unici: 962037\n",
+      "Numero tracce uniche: 30459\n",
+      "\n",
+      "Statistiche playcount:\n",
+      "count    9.711301e+06\n",
+      "mean     2.630946e+00\n",
+      "std      5.706324e+00\n",
+      "min      1.000000e+00\n",
+      "25%      1.000000e+00\n",
+      "50%      1.000000e+00\n",
+      "75%      2.000000e+00\n",
+      "max      2.948000e+03\n",
+      "Name: playcount, dtype: float64\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Numero utenti unici:\", df_hist[\"user_id\"].nunique())\n",
+    "print(\"Numero tracce uniche:\", df_hist[\"track_id\"].nunique())\n",
+    "\n",
+    "print(\"\\nStatistiche playcount:\")\n",
+    "print(df_hist[\"playcount\"].describe())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "30c20d52",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T16:02:30.893291Z",
+     "iopub.status.busy": "2026-04-11T16:02:30.892927Z",
+     "iopub.status.idle": "2026-04-11T16:02:32.386383Z",
+     "shell.execute_reply": "2026-04-11T16:02:32.384997Z"
+    },
+    "papermill": {
+     "duration": 1.502684,
+     "end_time": "2026-04-11T16:02:32.388492+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:30.885808+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Top 10 tracce per numero totale di ascolti:\n",
+      "track_id\n",
+      "TRONYHY128F92C9D11    527893\n",
+      "TRUFTBY128F93450B8    111615\n",
+      "TRZNAHL128F9327D5A    111596\n",
+      "TRCPXID128F92D5D3C     91461\n",
+      "TRPGPDK12903CCC651     91448\n",
+      "TRXWAZC128F9314B3E     87745\n",
+      "TROMKCG128F9320C09     87050\n",
+      "TRPFYYL128F92F7144     85079\n",
+      "TRGCHLH12903CB7352     78443\n",
+      "TRAALAH128E078234A     76893\n",
+      "Name: playcount, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "top_tracks = df_hist.groupby(\"track_id\")[\"playcount\"].sum().sort_values(ascending=False).head(10)\n",
+    "print(\"\\nTop 10 tracce per numero totale di ascolti:\")\n",
+    "print(top_tracks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc2baef8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005318,
+     "end_time": "2026-04-11T16:02:32.399128+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:32.393810+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Osservazioni\n",
+    "\n",
+    "- Il dataset contiene un numero molto elevato di utenti unici (~962k), indicando una forte eterogeneità nel comportamento di ascolto.\n",
+    "\n",
+    "- Il numero di tracce uniche (~30k) è significativamente inferiore rispetto agli utenti, suggerendo che molte tracce sono condivise tra diversi utenti.\n",
+    "\n",
+    "- La distribuzione di `playcount` è fortemente sbilanciata:\n",
+    "  - il valore mediano è 1\n",
+    "  - il 75% dei valori è ≤ 2\n",
+    "  → la maggior parte delle interazioni rappresenta pochi ascolti per coppia utente-traccia\n",
+    "\n",
+    "- La presenza di un valore massimo molto elevato (2948) indica l’esistenza di outlier, ovvero utenti che ascoltano alcune tracce in modo estremamente frequente.\n",
+    "\n",
+    "- Le tracce più popolari mostrano un numero totale di ascolti molto superiore rispetto alla media, evidenziando un comportamento tipico di distribuzione “long tail”, in cui poche tracce concentrano la maggior parte degli ascolti.\n",
+    "\n",
+    "- Il dataset sembra rappresentare dati già aggregati per coppia (`user_id`, `track_id`), dove `playcount` indica il numero totale di ascolti per quella specifica combinazione."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45ddf18e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005177,
+     "end_time": "2026-04-11T16:02:32.409413+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:32.404236+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Controllo qualità dei dati\n",
+    "\n",
+    "In questa sezione vengono analizzati gli aspetti legati alla qualità del dataset, in particolare:\n",
+    "\n",
+    "- presenza di valori nulli\n",
+    "- duplicati\n",
+    "- coerenza dei tipi di dato\n",
+    "- presenza di valori anomali\n",
+    "\n",
+    "L’obiettivo è individuare eventuali problemi che potrebbero influenzare le analisi successive o la modellazione del database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1970af1b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T16:02:32.421583Z",
+     "iopub.status.busy": "2026-04-11T16:02:32.421252Z",
+     "iopub.status.idle": "2026-04-11T16:02:33.407616Z",
+     "shell.execute_reply": "2026-04-11T16:02:33.406579Z"
+    },
+    "papermill": {
+     "duration": 0.995024,
+     "end_time": "2026-04-11T16:02:33.409682+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:32.414658+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Valori nulli per colonna:\n",
+      "track_id     0\n",
+      "user_id      0\n",
+      "playcount    0\n",
+      "dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Valori nulli per colonna:\")\n",
+    "print(df_hist.isnull().sum())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2381359",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005501,
+     "end_time": "2026-04-11T16:02:33.420776+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:33.415275+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Osservazioni\n",
+    "\n",
+    "- Il dataset non presenta valori nulli nelle colonne principali (`track_id`, `user_id`, `playcount`)\n",
+    "- I dati risultano quindi completi dal punto di vista strutturale"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d5034ecc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T16:02:33.434065Z",
+     "iopub.status.busy": "2026-04-11T16:02:33.433464Z",
+     "iopub.status.idle": "2026-04-11T16:02:42.454210Z",
+     "shell.execute_reply": "2026-04-11T16:02:42.453155Z"
+    },
+    "papermill": {
+     "duration": 9.03048,
+     "end_time": "2026-04-11T16:02:42.456602+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:33.426122+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Duplicati completi: 0\n",
+      "Duplicati su (user_id, track_id): 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Duplicati completi:\", df_hist.duplicated().sum())\n",
+    "\n",
+    "dup_user_track = df_hist.duplicated(subset=[\"user_id\", \"track_id\"]).sum()\n",
+    "print(\"Duplicati su (user_id, track_id):\", dup_user_track)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "55e2af56",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T16:02:42.469370Z",
+     "iopub.status.busy": "2026-04-11T16:02:42.469041Z",
+     "iopub.status.idle": "2026-04-11T16:02:42.994495Z",
+     "shell.execute_reply": "2026-04-11T16:02:42.993395Z"
+    },
+    "papermill": {
+     "duration": 0.534509,
+     "end_time": "2026-04-11T16:02:42.996725+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:42.462216+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Playcount = 0: 0\n",
+      "Playcount < 0: 0\n",
+      "\n",
+      "Top valori di playcount:\n",
+      "9690999    2948\n",
+      "7324831    1862\n",
+      "6644450    1762\n",
+      "2323614    1729\n",
+      "550863     1539\n",
+      "5708557    1467\n",
+      "6256435    1460\n",
+      "3083599    1336\n",
+      "9296648    1305\n",
+      "3905041    1222\n",
+      "Name: playcount, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Playcount = 0:\", (df_hist[\"playcount\"] == 0).sum())\n",
+    "print(\"Playcount < 0:\", (df_hist[\"playcount\"] < 0).sum())\n",
+    "\n",
+    "print(\"\\nTop valori di playcount:\")\n",
+    "print(df_hist[\"playcount\"].sort_values(ascending=False).head(10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5423409c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005691,
+     "end_time": "2026-04-11T16:02:43.008180+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:43.002489+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Osservazioni\n",
+    "\n",
+    "- Non sono presenti valori negativi o nulli per `playcount`\n",
+    "- Il valore minimo è 1, coerente con il significato di “numero di ascolti”\n",
+    "\n",
+    "- Sono presenti valori molto elevati (fino a ~3000), che rappresentano possibili outlier\n",
+    "\n",
+    "Questi valori non sono necessariamente errori, ma riflettono comportamenti reali (utenti molto attivi)\n",
+    "\n",
+    "Tuttavia, la loro presenza contribuisce alla forte asimmetria della distribuzione"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "72280dc1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T16:02:43.020626Z",
+     "iopub.status.busy": "2026-04-11T16:02:43.020291Z",
+     "iopub.status.idle": "2026-04-11T16:02:45.536627Z",
+     "shell.execute_reply": "2026-04-11T16:02:45.535595Z"
+    },
+    "papermill": {
+     "duration": 2.525004,
+     "end_time": "2026-04-11T16:02:45.538639+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:43.013635+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Utenti con almeno un record: 962037\n",
+      "Tracce presenti: 30459\n",
+      "Playcount minimo: 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# utenti senza ascolti\n",
+    "print(\"Utenti con almeno un record:\", df_hist[\"user_id\"].nunique())\n",
+    "\n",
+    "# tracce mai ascoltate\n",
+    "print(\"Tracce presenti:\", df_hist[\"track_id\"].nunique())\n",
+    "\n",
+    "# verifica playcount minimo\n",
+    "print(\"Playcount minimo:\", df_hist[\"playcount\"].min())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffa0306e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005569,
+     "end_time": "2026-04-11T16:02:45.549837+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:45.544268+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Conclusioni\n",
+    "\n",
+    "L’analisi della qualità dei dati evidenzia che il dataset `listening_history` presenta un elevato livello di consistenza e affidabilità:\n",
+    "\n",
+    "- non sono presenti valori nulli nelle colonne principali (`track_id`, `user_id`, `playcount`)\n",
+    "- non sono presenti duplicati, né completi né sulla coppia (`user_id`, `track_id`)\n",
+    "- i tipi di dato risultano coerenti con il significato delle variabili\n",
+    "- non sono presenti valori invalidi (zero o negativi) per `playcount`\n",
+    "\n",
+    "La coppia (`user_id`, `track_id`) può essere considerata una chiave logica del dataset, indicando che ogni record rappresenta un’interazione aggregata unica tra utente e traccia.\n",
+    "\n",
+    "I valori elevati di `playcount`, sebbene possano essere considerati outlier dal punto di vista statistico, riflettono comportamenti reali e non verranno trattati come errori.\n",
+    "\n",
+    "Nel complesso, il dataset non richiede interventi di pulizia strutturale significativi ed è pronto per le fasi successive di analisi e preprocessing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0eb35988",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00527,
+     "end_time": "2026-04-11T16:02:45.560502+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:45.555232+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Analisi della distribuzione di `playcount`\n",
+    "\n",
+    "In questa sezione viene analizzata la distribuzione della variabile `playcount`, che rappresenta il numero di ascolti per coppia (`user_id`, `track_id`).\n",
+    "\n",
+    "L’obiettivo è comprendere:\n",
+    "- la forma della distribuzione\n",
+    "- la presenza di asimmetrie\n",
+    "- l’impatto di eventuali outlier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4a57329a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T16:02:45.573414Z",
+     "iopub.status.busy": "2026-04-11T16:02:45.572714Z",
+     "iopub.status.idle": "2026-04-11T16:02:46.044058Z",
+     "shell.execute_reply": "2026-04-11T16:02:46.042984Z"
+    },
+    "papermill": {
+     "duration": 0.480208,
+     "end_time": "2026-04-11T16:02:46.046152+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:45.565944+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArMAAAGJCAYAAACZ7rtNAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAPedJREFUeJzt3Xl8Tdce9/HvyYiQBCERTcU8T6UiRbWVNoYaqoOqGmKqtvpoowOtmm5vKZdqa0gHU0dUUU+1WoJq3XSgUjVFEUPJYEwIEpL1/OFxrtMkJEc42fp5v17n9XLWXnvv316O+NrWXsdmjDECAAAALMjN1QUAAAAAziLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAihSY8eOlc1muyHnuuuuu3TXXXfZ369bt042m02LFy++Iee/ZN68ebLZbNq3b98NPW9R+PsY7tu3TzabTfPmzbtu5wCAokSYBZCvSyHt0qtEiRIKDg5WZGSk3n77bZ06dapIznP48GGNHTtW8fHxRXI8oLh5/fXXtWzZMleXAdyUCLMArmr8+PH66KOPNGvWLD3zzDOSpGeffVYNGzbUli1bHPqOGjVKZ8+eLdTxDx8+rHHjxhU6zH733Xf67rvvCrXP9dC7d2+dPXtWVapUcXUp16xKlSo6e/asevfu7epSbiqEWeD68XB1AQCKvw4dOqh58+b29yNHjtSaNWt0//33q0uXLtqxY4dKliwpSfLw8JCHx/X90XLmzBmVKlVKXl5e1/U8BeXu7i53d3dXl1EkLt2BBwCr4M4sAKfcc889evXVV7V//359/PHH9va85syuWrVKrVu3lr+/v0qXLq3atWvr5ZdflnRxnuvtt98uSYqKirJPabg0Z/Ouu+5SgwYNtGnTJt15550qVaqUfd/85mJmZ2fr5ZdfVlBQkHx8fNSlSxcdPHjQoU9oaKj69euXa9+/HzM0NNRhqsXlr3Xr1knKf87szJkzVb9+fXl7eys4OFhPP/20Tp48met8DRo00Pbt23X33XerVKlSqly5siZNmpSrtszMTI0ZM0Y1atSQt7e3QkJC9OKLLyozMzNX37y89957ql69ukqWLKkWLVrohx9+yNWnoHNmL13z+vXr9cQTT6h8+fLy9fVVnz59dOLEiSvum5WVpdGjR6tZs2by8/OTj4+P2rRpo7Vr19r7GGMUGhqqrl275tr/3Llz8vPz0xNPPOHQNnbsWNWqVUslSpRQpUqV1L17d+3Zs8feJyMjQ8OHD1dISIi8vb1Vu3Zt/ec//5ExpkDXb7PZNHbsWPv7S5/13bt3q1+/fvL395efn5+ioqJ05swZh/0yMjI0f/58+2cnr88eAOdwZxaA03r37q2XX35Z3333nQYNGpRnn23btun+++9Xo0aNNH78eHl7e2v37t3asGGDJKlu3boaP368Ro8ercGDB6tNmzaSpDvuuMN+jGPHjqlDhw569NFH9fjjjyswMPCKdf373/+WzWbTSy+9pNTUVE2bNk0RERGKj4+330EuqGnTpun06dMObW+++abi4+NVvnz5fPcbO3asxo0bp4iICD355JNKSEjQrFmz9Ouvv2rDhg3y9PS09z1x4oTat2+v7t2765FHHtHixYv10ksvqWHDhurQoYMkKScnR126dNGPP/6owYMHq27duvrjjz/05ptvateuXVf9L+zZs2friSee0B133KFnn31We/fuVZcuXVSuXDmFhIQUakwuN3ToUPn7+2vs2LH2a9y/f7/9Yby8pKen64MPPlDPnj01aNAgnTp1SrNnz1ZkZKR++eUXNWnSRDabTY8//rgmTZqk48ePq1y5cvb9/+///b9KT0/X448/LuniP17uv/9+xcbG6tFHH9WwYcN06tQprVq1Slu3blX16tVljFGXLl20du1aDRgwQE2aNNG3336rF154QYcOHdKbb77p9Bg88sgjqlq1qiZMmKDffvtNH3zwgSpWrKg33nhDkvTRRx9p4MCBatGihQYPHixJql69utPnA/A3BgDyMXfuXCPJ/Prrr/n28fPzM02bNrW/HzNmjLn8R8ubb75pJJkjR47ke4xff/3VSDJz587Nta1t27ZGkomJiclzW9u2be3v165daySZypUrm/T0dHv7okWLjCTz1ltv2duqVKli+vbte9Vj/t2lY40fP97edmmcEhMTjTHGpKamGi8vL3PfffeZ7Oxse7/p06cbSWbOnDm5ru/DDz+0t2VmZpqgoCDz4IMP2ts++ugj4+bmZn744QeHemJiYowks2HDhnxrzsrKMhUrVjRNmjQxmZmZ9vb33nvPSHK43sTExHx/Ly536ZqbNWtmsrKy7O2TJk0yksyXX37pcI2Xn+PChQsOdRhjzIkTJ0xgYKDp37+/vS0hIcFIMrNmzXLo26VLFxMaGmpycnKMMcbMmTPHSDJTp07NVeelPsuWLTOSzGuvveaw/aGHHjI2m83s3r37qtcvyYwZM8b+/tJn/fKajTHmgQceMOXLl3do8/HxyfPzBuDaMc0AwDUpXbr0FVc18Pf3lyR9+eWXysnJceoc3t7eioqKKnD/Pn36qEyZMvb3Dz30kCpVqqSvv/7aqfNfsn37dvXv319du3bVqFGj8u23evVqZWVl6dlnn5Wb2/9+zA4aNEi+vr5asWKFQ//SpUvb7zJKkpeXl1q0aKG9e/fa2z7//HPVrVtXderU0dGjR+2ve+65R5Ic/ov+7zZu3KjU1FQNGTLEYZ5xv3795OfnV/AByMPgwYMd7jI/+eST8vDwuOJYu7u72+vIycnR8ePHdeHCBTVv3ly//fabvV+tWrUUFhamTz75xN52/PhxffPNN+rVq5f9zu8XX3yhgIAA+8OJl7vU5+uvv5a7u7v+z//5Pw7bhw8fLmOMvvnmGyeu/qIhQ4Y4vG/Tpo2OHTum9PR0p48JoOD+0WF2/fr16ty5s4KDg2Wz2Qr9pOml+VJ/f/n4+FyfgoFi6PTp0w7B8e969OihVq1aaeDAgQoMDNSjjz6qRYsWFSrYVq5cuVAPe9WsWdPhvc1mU40aNa5pHdj09HR1795dlStX1ocffnjFtXT3798vSapdu7ZDu5eXl6pVq2bffsktt9yS63hly5Z1mHv6559/atu2bapQoYLDq1atWpKk1NTUq9bz93Hx9PRUtWrV8t2vIP5+zNKlS6tSpUpXHev58+erUaNGKlGihMqXL68KFSpoxYoVSktLc+jXp08fbdiwwX4Nn3/+uc6fP++w2sKePXtUu3btKz54uH//fgUHB+f6rNatW9e+3Vm33nqrw/uyZctK0lXnDgMoGv/oMJuRkaHGjRtrxowZTu3//PPPKykpyeFVr149Pfzww0VcKVA8/fXXX0pLS1ONGjXy7VOyZEmtX79eq1evVu/evbVlyxb16NFD9957r7Kzswt0nsLOcy2I/MJofjX169dPhw8f1rJly+Tr61ukteS3EoK57MGknJwcNWzYUKtWrcrz9dRTTxVpTdfTxx9/rH79+ql69eqaPXu2Vq5cqVWrVumee+7J9Y+cRx99VJ6enva7sx9//LGaN2+e6x8KRaWwnwupYL9/AK6ff3SY7dChg1577TU98MADeW7PzMzU888/r8qVK8vHx0dhYWH2p5eli3cggoKC7K+UlBRt375dAwYMuEFXALjWRx99JEmKjIy8Yj83Nze1a9dOU6dO1fbt2/Xvf/9ba9assf/XeFF/Y9iff/7p8N4Yo927dys0NNTeVrZs2VwrC0h536GbOHGili1bpg8//FB16tS56vkvrTebkJDg0J6VlaXExESn1qOtXr26jh8/rnbt2ikiIiLX60rh7tL5/j4u58+fV2JiYqFrudzfj3n69GklJSU5jPXfLV68WNWqVdOSJUvUu3dvRUZGKiIiQufOncvVt1y5curUqZM++eQT7d+/Xxs2bMi1Bm716tWVkJCg8+fP53vOKlWq6PDhw7mmxOzcudO+XfrfXdW/fzau5c6tVPSfcQD/848Os1czdOhQxcXFacGCBdqyZYsefvhhtW/fPtcP70s++OAD1apVy/40NnAzW7Nmjf71r3+patWq6tWrV779jh8/nqutSZMmkmRfUurS1Jy8wqUzPvzwQ4fQsnjxYiUlJdlXBpAuBqCffvpJWVlZ9ravvvoq1xJeq1ev1qhRo/TKK6+oW7duBTp/RESEvLy89PbbbzvcnZs9e7bS0tLUqVOnQl/TI488okOHDun999/Pte3s2bPKyMjId9/mzZurQoUKiomJcbjeefPmXfOYv/feew4hctasWbpw4YLDWP/dpTuZl4/Nzz//rLi4uDz79+7dW9u3b9cLL7wgd3d3Pfroow7bH3zwQR09elTTp0/Pte+lc3Ts2FHZ2dm5+rz55puy2Wz2en19fRUQEKD169c79Js5c2a+11MQPj4+Rfb5BuCIpbnyceDAAc2dO1cHDhxQcHCwpIvTClauXKm5c+fq9ddfd+h/7tw5ffLJJxoxYoQrygWuq2+++UY7d+7UhQsXlJKSojVr1mjVqlWqUqWKli9ffsVF9sePH6/169erU6dOqlKlilJTUzVz5kzdcsstat26taSLwdLf318xMTEqU6aM/X9Cqlat6lS95cqVU+vWrRUVFaWUlBRNmzZNNWrUcFg+bODAgVq8eLHat2+vRx55RHv27NHHH3+ca8mknj17qkKFCqpZs6bDerqSdO+99+a5TFiFChU0cuRIjRs3Tu3bt1eXLl2UkJCgmTNn6vbbb3d42KugevfurUWLFmnIkCFau3atWrVqpezsbO3cuVOLFi3St99+6/DFFpfz9PTUa6+9pieeeEL33HOPevToocTERM2dO/ea58xmZWWpXbt2euSRR+zX2Lp1a3Xp0iXffe6//34tWbJEDzzwgDp16qTExETFxMSoXr16uZZBk6ROnTqpfPny+vzzz9WhQwdVrFjRYXufPn304YcfKjo6Wr/88ovatGmjjIwMrV69Wk899ZS6du2qzp076+6779Yrr7yiffv2qXHjxvruu+/05Zdf6tlnn3X4fR84cKAmTpyogQMHqnnz5lq/fr127dp1TePUrFkzrV69WlOnTlVwcLCqVq2qsLCwazomgP/PhSspFCuSzNKlS+3vv/rqKyPJ+Pj4OLw8PDzMI488kmv/Tz/91Hh4eJjk5OQbWDVwfV1afunSy8vLywQFBZl7773XvPXWWw7LX13y96W5YmNjTdeuXU1wcLDx8vIywcHBpmfPnmbXrl0O+3355ZemXr16xsPDw2FppLZt25r69evnWV9+S3N99tlnZuTIkaZixYqmZMmSplOnTmb//v259p8yZYqpXLmy8fb2Nq1atTIbN27MdczLr//vr7Vr1zqM06WluS6ZPn26qVOnjvH09DSBgYHmySefNCdOnMh1DXldX9++fU2VKlUc2rKysswbb7xh6tevb7y9vU3ZsmVNs2bNzLhx40xaWlqeY3S5mTNnmqpVqxpvb2/TvHlzs379+lzXW9ilub7//nszePBgU7ZsWVO6dGnTq1cvc+zYsVzXePk5cnJyzOuvv26qVKlivL29TdOmTc1XX32V5zVf8tRTTxlJ5tNPP81z+5kzZ8wrr7xiqlatajw9PU1QUJB56KGHzJ49e+x9Tp06ZZ577jkTHBxsPD09Tc2aNc3kyZPty3ddfqwBAwYYPz8/U6ZMGfPII4+Y1NTUfJfm+vuyc3l9Hnbu3GnuvPNOU7JkSSOJZbqAImQzhhnq0sX5TEuXLrX/N+LChQvVq1cvbdu2Ldfk/ktzZS/Xrl07+fr6aunSpTeqZABwmXnz5ikqKkq//vprvneEi9Jzzz2n2bNnKzk5WaVKlbru5wNgHUwzyEfTpk2VnZ2t1NTUq86BTUxM1Nq1a7V8+fIbVB0A/HOcO3dOH3/8sR588EGCLIBc/tFh9vTp09q9e7f9fWJiouLj41WuXDnVqlVLvXr1Up8+fTRlyhQ1bdpUR44cUWxsrBo1auTwAMecOXNUqVKlKz7wAAAonNTUVK1evVqLFy/WsWPHNGzYMFeXBKAY+keH2Y0bN+ruu++2v4+OjpYk9e3bV/PmzdPcuXP12muvafjw4Tp06JACAgLUsmVL3X///fZ9cnJyNG/ePPXr1y/ftQYBAIW3fft29erVSxUrVtTbb79tXwUDAC7HnFkAAABYFuvMAgAAwLIIswAAALCsf9yc2ZycHB0+fFhlypTh6wUBAACKIWOMTp06peDgYLm5Xfne6z8uzB4+fFghISGuLgMAAABXcfDgQd1yyy1X7OPSMLt+/XpNnjxZmzZtUlJSksOXFuRn3bp1io6O1rZt2xQSEqJRo0apX79+BT5nmTJlJF0cHF9f32uoHgAAANdDenq6QkJC7LntSlwaZjMyMtS4cWP1799f3bt3v2r/xMREderUSUOGDNEnn3yi2NhYDRw4UJUqVVJkZGSBznlpaoGvry9hFgAAoBgryJRQl4bZDh06FOqLBmJiYlS1alVNmTJFklS3bl39+OOPevPNNwscZgEAAHDzsNRqBnFxcYqIiHBoi4yMVFxcXL77ZGZmKj093eEFAACAm4OlwmxycrICAwMd2gIDA5Wenq6zZ8/muc+ECRPk5+dnf/HwFwAAwM3DUmHWGSNHjlRaWpr9dfDgQVeXBAAAgCJiqaW5goKClJKS4tCWkpIiX19flSxZMs99vL295e3tfSPKAwAAwA1mqTuz4eHhio2NdWhbtWqVwsPDXVQRAAAAXMmlYfb06dOKj49XfHy8pItLb8XHx+vAgQOSLk4R6NOnj73/kCFDtHfvXr344ovauXOnZs6cqUWLFum5555zRfkAAABwMZeG2Y0bN6pp06Zq2rSpJCk6OlpNmzbV6NGjJUlJSUn2YCtJVatW1YoVK7Rq1So1btxYU6ZM0QcffMCyXAAAAP9QNmOMcXURN1J6err8/PyUlpbGlyYAAAAUQ4XJa5aaMwsAAABcjjALAAAAy7LU0lxWFTpiRaH675vY6TpVAgAAcHPhziwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLJcHmZnzJih0NBQlShRQmFhYfrll1+u2H/atGmqXbu2SpYsqZCQED333HM6d+7cDaoWAAAAxYlLw+zChQsVHR2tMWPG6LffflPjxo0VGRmp1NTUPPt/+umnGjFihMaMGaMdO3Zo9uzZWrhwoV5++eUbXDkAAACKA5eG2alTp2rQoEGKiopSvXr1FBMTo1KlSmnOnDl59v/vf/+rVq1a6bHHHlNoaKjuu+8+9ezZ86p3cwEAAHBzclmYzcrK0qZNmxQREfG/YtzcFBERobi4uDz3ueOOO7Rp0yZ7eN27d6++/vprdezYMd/zZGZmKj093eEFAACAm4OHq0589OhRZWdnKzAw0KE9MDBQO3fuzHOfxx57TEePHlXr1q1ljNGFCxc0ZMiQK04zmDBhgsaNG1ektQMAAKB4cPkDYIWxbt06vf7665o5c6Z+++03LVmyRCtWrNC//vWvfPcZOXKk0tLS7K+DBw/ewIoBAABwPbnszmxAQIDc3d2VkpLi0J6SkqKgoKA893n11VfVu3dvDRw4UJLUsGFDZWRkaPDgwXrllVfk5pY7m3t7e8vb27voLwAAAAAu57I7s15eXmrWrJliY2PtbTk5OYqNjVV4eHie+5w5cyZXYHV3d5ckGWOuX7EAAAAollx2Z1aSoqOj1bdvXzVv3lwtWrTQtGnTlJGRoaioKElSnz59VLlyZU2YMEGS1LlzZ02dOlVNmzZVWFiYdu/erVdffVWdO3e2h1oAAAD8c7g0zPbo0UNHjhzR6NGjlZycrCZNmmjlypX2h8IOHDjgcCd21KhRstlsGjVqlA4dOqQKFSqoc+fO+ve//+2qSwAAAIAL2cw/7P/n09PT5efnp7S0NPn6+t6Qc4aOWFGo/vsmdrpOlQAAABR/hclrllrNAAAAALgcYRYAAACWRZgFAACAZRFmAQAAYFmEWQAAAFgWYRYAAACWRZgFAACAZRFmAQAAYFmEWQAAAFgWYRYAAACWRZgFAACAZRFmAQAAYFmEWQAAAFgWYRYAAACWRZgFAACAZRFmAQAAYFmEWQAAAFgWYRYAAACWRZgFAACAZRFmAQAAYFmEWQAAAFgWYRYAAACWRZgFAACAZRFmAQAAYFmEWQAAAFgWYRYAAACWRZgFAACAZRFmAQAAYFmEWQAAAFgWYRYAAACWRZgFAACAZRFmAQAAYFmEWQAAAFgWYRYAAACWRZgFAACAZRFmAQAAYFmEWQAAAFgWYRYAAACWRZgFAACAZRFmAQAAYFmEWQAAAFgWYRYAAACWRZgFAACAZRFmAQAAYFmEWQAAAFgWYRYAAACWRZgFAACAZRFmAQAAYFmEWQAAAFiWh7M7/vXXX1q+fLkOHDigrKwsh21Tp04t8HFmzJihyZMnKzk5WY0bN9Y777yjFi1a5Nv/5MmTeuWVV7RkyRIdP35cVapU0bRp09SxY0dnLwUAAAAW5VSYjY2NVZcuXVStWjXt3LlTDRo00L59+2SM0W233Vbg4yxcuFDR0dGKiYlRWFiYpk2bpsjISCUkJKhixYq5+mdlZenee+9VxYoVtXjxYlWuXFn79++Xv7+/M5cBAAAAi3NqmsHIkSP1/PPP648//lCJEiX0xRdf6ODBg2rbtq0efvjhAh9n6tSpGjRokKKiolSvXj3FxMSoVKlSmjNnTp7958yZo+PHj2vZsmVq1aqVQkND1bZtWzVu3NiZywAAAIDFORVmd+zYoT59+kiSPDw8dPbsWZUuXVrjx4/XG2+8UaBjZGVladOmTYqIiPhfMW5uioiIUFxcXJ77LF++XOHh4Xr66acVGBioBg0a6PXXX1d2dna+58nMzFR6errDCwAAADcHp8Ksj4+PfZ5spUqVtGfPHvu2o0ePFugYR48eVXZ2tgIDAx3aAwMDlZycnOc+e/fu1eLFi5Wdna2vv/5ar776qqZMmaLXXnst3/NMmDBBfn5+9ldISEiB6gMAAEDx59Sc2ZYtW+rHH39U3bp11bFjRw0fPlx//PGHlixZopYtWxZ1jXY5OTmqWLGi3nvvPbm7u6tZs2Y6dOiQJk+erDFjxuS5z8iRIxUdHW1/n56eTqAFAAC4STgVZqdOnarTp09LksaNG6fTp09r4cKFqlmzZoFXMggICJC7u7tSUlIc2lNSUhQUFJTnPpUqVZKnp6fc3d3tbXXr1lVycrKysrLk5eWVax9vb295e3sX9NIAAABgIU6F2WrVqtl/7ePjo5iYmEIfw8vLS82aNVNsbKy6desm6eKd19jYWA0dOjTPfVq1aqVPP/1UOTk5cnO7OENi165dqlSpUp5BFgAAADc3p+bM9u/fX/Pnz8/Vnp6erv79+xf4ONHR0Xr//fc1f/587dixQ08++aQyMjIUFRUlSerTp49Gjhxp7//kk0/q+PHjGjZsmHbt2qUVK1bo9ddf19NPP+3MZQAAAMDinLozO2/ePC1cuFCbNm3StGnT7HdJz549q/nz5+e7tNbf9ejRQ0eOHNHo0aOVnJysJk2aaOXKlfaHwg4cOGA/tiSFhITo22+/1XPPPadGjRqpcuXKGjZsmF566SVnLgMAAAAWZzPGmMLu5ObmpjVr1mjgwIGqWrWqFi1apLJlyyolJUXBwcFXXCrL1dLT0+Xn56e0tDT5+vrekHOGjlhRqP77Jna6TpUAAAAUf4XJa05NM5CkevXq6eeff9b58+fVokUL7dixw9lDAQAAAE5xKszabDZJUvny5bV69Wq1bdtW4eHhWr58eZEWBwAAAFyJU3NmL5+Z4OHhoQ8++ED16tXTU089VWSFAQAAAFfjVJhdu3atypUr59AWHR2tRo0aacOGDUVSGAAAAHA1ToXZtm3b5tkeERGhiIiIayoIAAAAKCinwmx2drbmzZun2NhYpaamKicnx2H7mjVriqQ4AAAA4EqcCrPDhg3TvHnz1KlTJzVo0MD+QBgAAABwIzkVZhcsWKBFixapY8eORV0PAAAAUGBOLc3l5eWlGjVqFHUtAAAAQKE4FWaHDx+ut956S058eRgAAABQZJyaZvDjjz9q7dq1+uabb1S/fn15eno6bF+yZEmRFAcAAABciVNh1t/fXw888EBR1wIAAAAUilNhdu7cuUVdBwAAAFBoTs2ZlaQLFy5o9erVevfdd3Xq1ClJ0uHDh3X69OkiKw4AAAC4EqfuzO7fv1/t27fXgQMHlJmZqXvvvVdlypTRG2+8oczMTMXExBR1nQAAAEAuTt2ZHTZsmJo3b64TJ06oZMmS9vYHHnhAsbGxRVYcAAAAcCVO3Zn94Ycf9N///ldeXl4O7aGhoTp06FCRFAYAAABcjVN3ZnNycpSdnZ2r/a+//lKZMmWuuSgAAACgIJwKs/fdd5+mTZtmf2+z2XT69GmNGTOGr7gFAADADePUNIMpU6YoMjJS9erV07lz5/TYY4/pzz//VEBAgD777LOirhEAAADIk1Nh9pZbbtHvv/+uBQsWaMuWLTp9+rQGDBigXr16OTwQBgAAAFxPToVZSfLw8NDjjz9elLUAAAAAheJUmP3www+vuL1Pnz5OFQMAAAAUhlNhdtiwYQ7vz58/rzNnzsjLy0ulSpUizAIAAOCGcGo1gxMnTji8Tp8+rYSEBLVu3ZoHwAAAAHDDOBVm81KzZk1NnDgx111bAAAA4HopsjArXXwo7PDhw0V5SAAAACBfTs2ZXb58ucN7Y4ySkpI0ffp0tWrVqkgKAwAAAK7GqTDbrVs3h/c2m00VKlTQPffcoylTphRFXQAAAMBVORVmc3JyiroOAAAAoNCKdM4sAAAAcCM5dWc2Ojq6wH2nTp3qzCkAAACAq3IqzG7evFmbN2/W+fPnVbt2bUnSrl275O7urttuu83ez2azFU2VAAAAQB6cCrOdO3dWmTJlNH/+fJUtW1bSxS9SiIqKUps2bTR8+PAiLRIAAADIi1NzZqdMmaIJEybYg6wklS1bVq+99hqrGQAAAOCGcSrMpqen68iRI7najxw5olOnTl1zUQAAAEBBOBVmH3jgAUVFRWnJkiX666+/9Ndff+mLL77QgAED1L1796KuEQAAAMiTU3NmY2Ji9Pzzz+uxxx7T+fPnLx7Iw0MDBgzQ5MmTi7RAAAAAID9OhdlSpUpp5syZmjx5svbs2SNJql69unx8fIq0OAAAAOBKrulLE5KSkpSUlKSaNWvKx8dHxpiiqgsAAAC4KqfC7LFjx9SuXTvVqlVLHTt2VFJSkiRpwIABLMsFAACAG8apMPvcc8/J09NTBw4cUKlSpeztPXr00MqVK4usOAAAAOBKnJoz+9133+nbb7/VLbfc4tBes2ZN7d+/v0gKAwAAAK7GqTuzGRkZDndkLzl+/Li8vb2vuSgAAACgIJwKs23atNGHH35of2+z2ZSTk6NJkybp7rvvLrLiAAAAgCtxaprBpEmT1K5dO23cuFFZWVl68cUXtW3bNh0/flwbNmwo6hoBAACAPDl1Z7ZBgwbatWuXWrdura5duyojI0Pdu3fX5s2bVb169aKuEQAAAMhToe/Mnj9/Xu3bt1dMTIxeeeWV61ETAAAAUCCFvjPr6empLVu2XI9aAAAAgEJxaprB448/rtmzZxd1LQAAAEChOPUA2IULFzRnzhytXr1azZo1k4+Pj8P2qVOnFup4M2bM0OTJk5WcnKzGjRvrnXfeUYsWLa6634IFC9SzZ0917dpVy5YtK9Q5AQAAYH2FCrN79+5VaGiotm7dqttuu02StGvXLoc+NputUAUsXLhQ0dHRiomJUVhYmKZNm6bIyEglJCSoYsWK+e63b98+Pf/882rTpk2hzgcAAICbh80YYwra2d3dXUlJSfaQ2aNHD7399tsKDAx0uoCwsDDdfvvtmj59uiQpJydHISEheuaZZzRixIg898nOztadd96p/v3764cfftDJkycLfGc2PT1dfn5+SktLk6+vr9N1F0boiBWF6r9vYqfrVAkAAEDxV5i8Vqg5s3/Pvd98840yMjIKX+H/l5WVpU2bNikiIuJ/Bbm5KSIiQnFxcfnuN378eFWsWFEDBgy46jkyMzOVnp7u8AIAAMDNwakHwC4pxE3dPB09elTZ2dm57uwGBgYqOTk5z31+/PFHzZ49W++//36BzjFhwgT5+fnZXyEhIddUMwAAAIqPQoVZm82Wa05sYefIXotTp06pd+/eev/99xUQEFCgfUaOHKm0tDT76+DBg9e5SgAAANwohXoAzBijfv36ydvbW5J07tw5DRkyJNdqBkuWLCnQ8QICAuTu7q6UlBSH9pSUFAUFBeXqv2fPHu3bt0+dO3e2t+Xk5Fy8EA8PJSQk5PoGMm9vb3u9AAAAuLkUKsz27dvX4f3jjz9+TSf38vJSs2bNFBsbq27dukm6GE5jY2M1dOjQXP3r1KmjP/74w6Ft1KhROnXqlN566y2mEAAAAPzDFCrMzp07t8gLiI6OVt++fdW8eXO1aNFC06ZNU0ZGhqKioiRJffr0UeXKlTVhwgSVKFFCDRo0cNjf399fknK1AwAA4Obn1JcmFKUePXroyJEjGj16tJKTk9WkSROtXLnS/lDYgQMH5OZ2Tc+pAQAA4CZVqHVmbwasMwsAAFC8Xbd1ZgEAAIDihDALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsq1iE2RkzZig0NFQlSpRQWFiYfvnll3z7vv/++2rTpo3Kli2rsmXLKiIi4or9AQAAcPNyeZhduHChoqOjNWbMGP32229q3LixIiMjlZqammf/devWqWfPnlq7dq3i4uIUEhKi++67T4cOHbrBlQMAAMDVbMYY48oCwsLCdPvtt2v69OmSpJycHIWEhOiZZ57RiBEjrrp/dna2ypYtq+nTp6tPnz5X7Z+eni4/Pz+lpaXJ19f3musviNARKwrVf9/ETtepEgAAgOKvMHnNpXdms7KytGnTJkVERNjb3NzcFBERobi4uAId48yZMzp//rzKlSuX5/bMzEylp6c7vAAAAHBzcGmYPXr0qLKzsxUYGOjQHhgYqOTk5AId46WXXlJwcLBDIL7chAkT5OfnZ3+FhIRcc90AAAAoHlw+Z/ZaTJw4UQsWLNDSpUtVokSJPPuMHDlSaWlp9tfBgwdvcJUAAAC4XjxcefKAgAC5u7srJSXFoT0lJUVBQUFX3Pc///mPJk6cqNWrV6tRo0b59vP29pa3t3eR1AsAAIDixaV3Zr28vNSsWTPFxsba23JychQbG6vw8PB895s0aZL+9a9/aeXKlWrevPmNKBUAAADFkEvvzEpSdHS0+vbtq+bNm6tFixaaNm2aMjIyFBUVJUnq06ePKleurAkTJkiS3njjDY0ePVqffvqpQkND7XNrS5curdKlS7vsOgAAAHDjuTzM9ujRQ0eOHNHo0aOVnJysJk2aaOXKlfaHwg4cOCA3t//dQJ41a5aysrL00EMPORxnzJgxGjt27I0sHQAAAC7m8nVmbzTWmQUAACjeLLPOLAAAAHAtCLMAAACwLMIsAAAALIswCwAAAMsizAIAAMCyCLMAAACwLMIsAAAALIswCwAAAMsizAIAAMCyCLMAAACwLMIsAAAALIswCwAAAMsizAIAAMCyCLMAAACwLMIsAAAALIswCwAAAMsizAIAAMCyCLMAAACwLMIsAAAALIswCwAAAMsizAIAAMCyCLMAAACwLMIsAAAALIswCwAAAMsizAIAAMCyCLMAAACwLMIsAAAALIswCwAAAMsizAIAAMCyCLMAAACwLMIsAAAALIswCwAAAMsizAIAAMCyCLMAAACwLMIsAAAALIswCwAAAMsizAIAAMCyCLMAAACwLMIsAAAALIswCwAAAMsizAIAAMCyCLMAAACwLMIsAAAALIswCwAAAMsizAIAAMCyCLMAAACwLMIsAAAALIswCwAAAMsizAIAAMCyCLMAAACwrGIRZmfMmKHQ0FCVKFFCYWFh+uWXX67Y//PPP1edOnVUokQJNWzYUF9//fUNqhQAAADFicvD7MKFCxUdHa0xY8bot99+U+PGjRUZGanU1NQ8+//3v/9Vz549NWDAAG3evFndunVTt27dtHXr1htcOQAAAFzNZowxriwgLCxMt99+u6ZPny5JysnJUUhIiJ555hmNGDEiV/8ePXooIyNDX331lb2tZcuWatKkiWJiYq56vvT0dPn5+SktLU2+vr5FdyFXEDpiRaH675vY6TpVAgAAUPwVJq953KCa8pSVlaVNmzZp5MiR9jY3NzdFREQoLi4uz33i4uIUHR3t0BYZGally5bl2T8zM1OZmZn292lpaZIuDtKNkpN5plD9b33u8wL33TousrDlAAAAFGuXclpB7rm6NMwePXpU2dnZCgwMdGgPDAzUzp0789wnOTk5z/7Jycl59p8wYYLGjRuXqz0kJMTJqosXv2murgAAAOD6OHXqlPz8/K7Yx6Vh9kYYOXKkw53cnJwcHT9+XOXLl5fNZrvu509PT1dISIgOHjx4w6Y14H8Yf9di/F2HsXctxt91GHvXKqrxN8bo1KlTCg4Ovmpfl4bZgIAAubu7KyUlxaE9JSVFQUFBee4TFBRUqP7e3t7y9vZ2aPP393e+aCf5+vryh8qFGH/XYvxdh7F3LcbfdRh71yqK8b/aHdlLXLqagZeXl5o1a6bY2Fh7W05OjmJjYxUeHp7nPuHh4Q79JWnVqlX59gcAAMDNy+XTDKKjo9W3b181b95cLVq00LRp05SRkaGoqChJUp8+fVS5cmVNmDBBkjRs2DC1bdtWU6ZMUadOnbRgwQJt3LhR7733nisvAwAAAC7g8jDbo0cPHTlyRKNHj1ZycrKaNGmilStX2h/yOnDggNzc/ncD+Y477tCnn36qUaNG6eWXX1bNmjW1bNkyNWjQwFWXcEXe3t4aM2ZMrqkOuDEYf9di/F2HsXctxt91GHvXcsX4u3ydWQAAAMBZLv8GMAAAAMBZhFkAAABYFmEWAAAAlkWYBQAAgGURZq+zGTNmKDQ0VCVKlFBYWJh++eUXV5dkeWPHjpXNZnN41alTx7793Llzevrpp1W+fHmVLl1aDz74YK4v2jhw4IA6deqkUqVKqWLFinrhhRd04cKFG30plrB+/Xp17txZwcHBstlsWrZsmcN2Y4xGjx6tSpUqqWTJkoqIiNCff/7p0Of48ePq1auXfH195e/vrwEDBuj06dMOfbZs2aI2bdqoRIkSCgkJ0aRJk673pRV7Vxv7fv365fqz0L59e4c+jL1zJkyYoNtvv11lypRRxYoV1a1bNyUkJDj0KaqfNevWrdNtt90mb29v1ahRQ/Pmzbvel1fsFWT877rrrlyf/yFDhjj0YfydM2vWLDVq1Mj+xQfh4eH65ptv7NuL3Wff4LpZsGCB8fLyMnPmzDHbtm0zgwYNMv7+/iYlJcXVpVnamDFjTP369U1SUpL9deTIEfv2IUOGmJCQEBMbG2s2btxoWrZsae644w779gsXLpgGDRqYiIgIs3nzZvP111+bgIAAM3LkSFdcTrH39ddfm1deecUsWbLESDJLly512D5x4kTj5+dnli1bZn7//XfTpUsXU7VqVXP27Fl7n/bt25vGjRubn376yfzwww+mRo0apmfPnvbtaWlpJjAw0PTq1cts3brVfPbZZ6ZkyZLm3XffvVGXWSxdbez79u1r2rdv7/Bn4fjx4w59GHvnREZGmrlz55qtW7ea+Ph407FjR3Prrbea06dP2/sUxc+avXv3mlKlSpno6Gizfft288477xh3d3ezcuXKG3q9xU1Bxr9t27Zm0KBBDp//tLQ0+3bG33nLly83K1asMLt27TIJCQnm5ZdfNp6enmbr1q3GmOL32SfMXkctWrQwTz/9tP19dna2CQ4ONhMmTHBhVdY3ZswY07hx4zy3nTx50nh6eprPP//c3rZjxw4jycTFxRljLgYENzc3k5ycbO8za9Ys4+vrazIzM69r7Vb390CVk5NjgoKCzOTJk+1tJ0+eNN7e3uazzz4zxhizfft2I8n8+uuv9j7ffPONsdls5tChQ8YYY2bOnGnKli3rMP4vvfSSqV279nW+IuvIL8x27do1330Y+6KTmppqJJnvv//eGFN0P2tefPFFU79+fYdz9ejRw0RGRl7vS7KUv4+/MRfD7LBhw/Ldh/EvWmXLljUffPBBsfzsM83gOsnKytKmTZsUERFhb3Nzc1NERITi4uJcWNnN4c8//1RwcLCqVaumXr166cCBA5KkTZs26fz58w7jXqdOHd166632cY+Li1PDhg3tX8whSZGRkUpPT9e2bdtu7IVYXGJiopKTkx3G28/PT2FhYQ7j7e/vr+bNm9v7REREyM3NTT///LO9z5133ikvLy97n8jISCUkJOjEiRM36Gqsad26dapYsaJq166tJ598UseOHbNvY+yLTlpamiSpXLlykoruZ01cXJzDMS714e8JR38f/0s++eQTBQQEqEGDBho5cqTOnDlj38b4F43s7GwtWLBAGRkZCg8PL5affZd/A9jN6ujRo8rOznb4jZSkwMBA7dy500VV3RzCwsI0b9481a5dW0lJSRo3bpzatGmjrVu3Kjk5WV5eXvL393fYJzAwUMnJyZKk5OTkPH9fLm1DwV0ar7zG8/LxrlixosN2Dw8PlStXzqFP1apVcx3j0rayZctel/qtrn379urevbuqVq2qPXv26OWXX1aHDh0UFxcnd3d3xr6I5OTk6Nlnn1WrVq3s3zZZVD9r8uuTnp6us2fPqmTJktfjkiwlr/GXpMcee0xVqlRRcHCwtmzZopdeekkJCQlasmSJJMb/Wv3xxx8KDw/XuXPnVLp0aS1dulT16tVTfHx8sfvsE2ZhOR06dLD/ulGjRgoLC1OVKlW0aNGif/QPHvzzPProo/ZfN2zYUI0aNVL16tW1bt06tWvXzoWV3Vyefvppbd26VT/++KOrS/lHym/8Bw8ebP91w4YNValSJbVr10579uxR9erVb3SZN53atWsrPj5eaWlpWrx4sfr27avvv//e1WXliWkG10lAQIDc3d1zPd2XkpKioKAgF1V1c/L391etWrW0e/duBQUFKSsrSydPnnToc/m4BwUF5fn7cmkbCu7SeF3pcx4UFKTU1FSH7RcuXNDx48f5PSli1apVU0BAgHbv3i2JsS8KQ4cO1VdffaW1a9fqlltusbcX1c+a/Pr4+vryj3PlP/55CQsLkySHzz/j7zwvLy/VqFFDzZo104QJE9S4cWO99dZbxfKzT5i9Try8vNSsWTPFxsba23JychQbG6vw8HAXVnbzOX36tPbs2aNKlSqpWbNm8vT0dBj3hIQEHThwwD7u4eHh+uOPPxz+kl+1apV8fX1Vr169G16/lVWtWlVBQUEO452enq6ff/7ZYbxPnjypTZs22fusWbNGOTk59r98wsPDtX79ep0/f97eZ9WqVapduzb/zV0If/31l44dO6ZKlSpJYuyvhTFGQ4cO1dKlS7VmzZpcUzGK6mdNeHi4wzEu9fmn/z1xtfHPS3x8vCQ5fP4Z/6KTk5OjzMzM4vnZL/zzbCioBQsWGG9vbzNv3jyzfft2M3jwYOPv7+/wdB8Kb/jw4WbdunUmMTHRbNiwwURERJiAgACTmppqjLm4ZMitt95q1qxZYzZu3GjCw8NNeHi4ff9LS4bcd999Jj4+3qxcudJUqFCBpbnycerUKbN582azefNmI8lMnTrVbN682ezfv98Yc3FpLn9/f/Pll1+aLVu2mK5du+a5NFfTpk3Nzz//bH788UdTs2ZNh+WhTp48aQIDA03v3r3N1q1bzYIFC0ypUqX+8ctDXWnsT506ZZ5//nkTFxdnEhMTzerVq81tt91matasac6dO2c/BmPvnCeffNL4+fmZdevWOSz9dObMGXufovhZc2l5ohdeeMHs2LHDzJgxg6WhzNXHf/fu3Wb8+PFm48aNJjEx0Xz55ZemWrVq5s4777Qfg/F33ogRI8z3339vEhMTzZYtW8yIESOMzWYz3333nTGm+H32CbPX2TvvvGNuvfVW4+XlZVq0aGF++uknV5dkeT169DCVKlUyXl5epnLlyqZHjx5m9+7d9u1nz541Tz31lClbtqwpVaqUeeCBB0xSUpLDMfbt22c6dOhgSpYsaQICAszw4cPN+fPnb/SlWMLatWuNpFyvvn37GmMuLs/16quvmsDAQOPt7W3atWtnEhISHI5x7Ngx07NnT1O6dGnj6+troqKizKlTpxz6/P7776Z169bG29vbVK5c2UycOPFGXWKxdaWxP3PmjLnvvvtMhQoVjKenp6lSpYoZNGhQrn8sM/bOyWvcJZm5c+fa+xTVz5q1a9eaJk2aGC8vL1OtWjWHc/xTXW38Dxw4YO68805Trlw54+3tbWrUqGFeeOEFh3VmjWH8ndW/f39TpUoV4+XlZSpUqGDatWtnD7LGFL/Pvs0YYwp/PxcAAABwPebMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAgAAwLIIswAAALAswiwAAAAsizALAAAAyyLMAsB1FhoaqmnTprm6DAC4KRFmAQBOGTt2rJo0aeLqMgD8wxFmAQAAYFmEWQC4RnfddZeGDh2qoUOHys/PTwEBAXr11VdljMmz/9SpU9WwYUP5+PgoJCRETz31lE6fPi1JysjIkK+vrxYvXuywz7Jly+Tj46NTp05Jkv766y/17NlT5cqVk4+Pj5o3b66ff/7Z3n/WrFmqXr26vLy8VLt2bX300Uf2bfv27ZPNZlN8fLy97eTJk7LZbFq3bp0kad26dbLZbIqNjVXz5s1VqlQp3XHHHUpISJAkzZs3T+PGjdPvv/8um80mm82mefPmXetQAkChEWYBoAjMnz9fHh4e+uWXX/TWW29p6tSp+uCDD/Ls6+bmprffflvbtm3T/PnztWbNGr344ouSJB8fHz366KOaO3euwz5z587VQw89pDJlyuj06dNq27atDh06pOXLl+v333/Xiy++qJycHEnS0qVLNWzYMA0fPlxbt27VE088oaioKK1du7bQ1/XKK69oypQp2rhxozw8PNS/f39JUo8ePTR8+HDVr19fSUlJSkpKUo8ePQp9fAC4ZgYAcE3atm1r6tata3JycuxtL730kqlbt64xxpgqVaqYN998M9/9P//8c1O+fHn7+59//tm4u7ubw4cPG2OMSUlJMR4eHmbdunXGGGPeffddU6ZMGXPs2LE8j3fHHXeYQYMGObQ9/PDDpmPHjsYYYxITE40ks3nzZvv2EydOGElm7dq1xhhj1q5daySZ1atX2/usWLHCSDJnz541xhgzZswY07hx4yuMDABcf9yZBYAi0LJlS9lsNvv78PBw/fnnn8rOzs7Vd/Xq1WrXrp0qV66sMmXKqHfv3jp27JjOnDkjSWrRooXq16+v+fPnS5I+/vhjValSRXfeeackKT4+Xk2bNlW5cuXyrGXHjh1q1aqVQ1urVq20Y8eOQl9Xo0aN7L+uVKmSJCk1NbXQxwGA64UwCwA30L59+3T//ferUaNG+uKLL7Rp0ybNmDFDkpSVlWXvN3DgQPsc1Llz5yoqKsoelkuWLHlNNbi5XfzRby6b03v+/Pk8+3p6etp/fen8l6YzAEBxQJgFgCJw+cNXkvTTTz+pZs2acnd3d2jftGmTcnJyNGXKFLVs2VK1atXS4cOHcx3v8ccf1/79+/X2229r+/bt6tu3r31bo0aNFB8fr+PHj+dZS926dbVhwwaHtg0bNqhevXqSpAoVKkiSkpKS7NsvfxisoLy8vPK88wwANxJhFgCKwIEDBxQdHa2EhAR99tlneueddzRs2LBc/WrUqKHz58/rnXfe0d69e/XRRx8pJiYmV7+yZcuqe/fueuGFF3TffffplltusW/r2bOngoKC1K1bN23YsEF79+7VF198obi4OEnSCy+8oHnz5mnWrFn6888/NXXqVC1ZskTPP/+8pIt3dlu2bKmJEydqx44d+v777zVq1KhCX3NoaKgSExMVHx+vo0ePKjMzs9DHAIBrRZgFgCLQp08fnT17Vi1atNDTTz+tYcOGafDgwbn6NW7cWFOnTtUbb7yhBg0a6JNPPtGECRPyPOaAAQOUlZVlX0HgEi8vL3333XeqWLGiOnbsqIYNG2rixIn2u8DdunXTW2+9pf/85z+qX7++3n33Xc2dO1d33XWX/Rhz5szRhQsX1KxZMz377LN67bXXCn3NDz74oNq3b6+7775bFSpU0GeffVboYwDAtbIZk89CiACAArnrrrvUpEmTIv/K2o8++kjPPfecDh8+LC8vryI9NgDcLDxcXQAAwNGZM2eUlJSkiRMn6oknniDIAsAVMM0AAIqZSZMmqU6dOgoKCtLIkSNdXQ4AFGtMMwAAAIBlcWcWAAAAlkWYBQAAgGURZgEAAGBZhFkAAABYFmEWAAAAlkWYBQAAgGURZgEAAGBZhFkAAABY1v8DDO7+iFjWqCwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.figure(figsize=(8,4))\n",
+    "plt.hist(df_hist[\"playcount\"], bins=50)\n",
+    "plt.title(\"Distribuzione di playcount\")\n",
+    "plt.xlabel(\"playcount\")\n",
+    "plt.ylabel(\"Frequenza\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97c273ab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006002,
+     "end_time": "2026-04-11T16:02:46.058617+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:46.052615+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Osservazioni\n",
+    "\n",
+    "- La distribuzione risulta fortemente sbilanciata verso valori bassi\n",
+    "- La maggior parte dei record ha `playcount` pari a 1 o 2\n",
+    "- I valori più elevati sono poco frequenti e difficilmente visibili nella scala lineare\n",
+    "\n",
+    "Questo comportamento è tipico di dataset reali di interazioni utente-contenuto"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b33eb23d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T16:02:46.072737Z",
+     "iopub.status.busy": "2026-04-11T16:02:46.071913Z",
+     "iopub.status.idle": "2026-04-11T16:02:46.675021Z",
+     "shell.execute_reply": "2026-04-11T16:02:46.674007Z"
+    },
+    "papermill": {
+     "duration": 0.6126,
+     "end_time": "2026-04-11T16:02:46.677143+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:46.064543+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAqYAAAGJCAYAAABYafHhAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAPXdJREFUeJzt3Xd8FNX+//H3QsgSkpACoQRCQi8BNIq0KEVAiEix0KQGxIsgHQvglaI0lSIqAfx6AyhFREEsFOnSrgGNgvQWqoKUhAQMkMzvD3/Zy5KAyZowE/J6Ph770Dl7dvYzZzfhnbMzZ22GYRgCAAAATJbP7AIAAAAAiWAKAAAAiyCYAgAAwBIIpgAAALAEgikAAAAsgWAKAAAASyCYAgAAwBIIpgAAALAEgikAAAAsgWAK5IDRo0fLZrPdledq1KiRGjVq5NjesGGDbDablixZcleeP82cOXNks9l07Nixu/q8WdGjRw+FhISYXcbfuttjabPZNHr06LvyXH/n1lpyYiysdLwAnBFMgb+R9g9j2q1gwYIKDAxU8+bNNX36dF2+fDlbnuf06dMaPXq0YmNjs2V/uLfMmDFDc+bMMbsM3AP4XQMrI5gCmTR27Fh9/PHHioqKUv/+/SVJgwYNUo0aNfTLL7849X3ttdd09erVLO3/9OnTGjNmTJb/sVi9erVWr16dpcfkhK5du+rq1asKDg42u5RcL6OxzMlgevXqVb322ms5su9/ivdV9nP1dw1wN7iZXQCQW0RERKhWrVqO7eHDh2vdunV64okn1Lp1a+3du1ceHh6SJDc3N7m55eyP15UrV1SoUCG5u7vn6PNkVv78+ZU/f36zy8jVkpKS5OnpedfHsmDBgnftubKK9xWQtzBjCvwDjz76qP79738rLi5On3zyiaM9o3NMv/vuOz388MPy9fWVl5eXKleurBEjRkj667zQhx56SJIUGRnpOG0gbYasUaNGql69unbu3KkGDRqoUKFCjsfeeo5pmpSUFI0YMUIlSpSQp6enWrdurRMnTjj1CQkJUY8ePdI99tZ9hoSEOJ3OcPNtw4YNkm5/LuCMGTMUGhoqu92uwMBA9evXT5cuXUr3fNWrV9eePXvUuHFjFSpUSKVKldJbb72Vrrbk5GSNGjVKFSpUkN1uV1BQkF5++WUlJyen65sZSUlJGjp0qIKCgmS321W5cmW98847MgzDqd/Vq1c1YMAAFS1aVN7e3mrdurVOnTqV7nzFuLg49e3bV5UrV5aHh4eKFCmidu3apRuXtPHauHGj+vbtq2LFiql06dIZjmVISIh+/fVXbdy40THuaa9PWt/NmzdrwIABCggIkK+vr/71r3/p2rVrunTpkrp16yY/Pz/5+fnp5ZdfTndsGZ1zeerUKfXq1UuBgYGy2+0qW7asXnjhBV27dk2SdOHCBQ0bNkw1atSQl5eXChcurIiICP3888+ZGvfk5GQNHjxYAQEBjvE8efJkun6ZPce0R48e8vLy0pEjR9S8eXN5enoqMDBQY8eOTXe8t8rMa3bkyBHZbDZNnTo13eO3bt0qm82mhQsXOtr+bvzS9tmuXTv5+/urUKFCqlu3rr755ptMHX/aueRpP39S5n6O/u53DWA2ZkyBf6hr164aMWKEVq9erd69e2fY59dff9UTTzyhmjVrauzYsbLb7Tp06JC2bNkiSapatarGjh2r119/Xc8//7weeeQRSVL9+vUd+zh//rwiIiLUsWNHdenSRcWLF79jXePGjZPNZtMrr7yis2fPatq0aWratKliY2MdM7uZNW3aNCUmJjq1TZ06VbGxsSpSpMhtHzd69GiNGTNGTZs21QsvvKD9+/crKipKMTEx2rJliwoUKODoe/HiRbVo0UJPPfWU2rdvryVLluiVV15RjRo1FBERIUlKTU1V69attXnzZj3//POqWrWqdu3apalTp+rAgQNatmxZlo7LMAy1bt1a69evV69evXT//fdr1apVeumll3Tq1CmnENKjRw8tXrxYXbt2Vd26dbVx40a1bNky3T5jYmK0detWdezYUaVLl9axY8cUFRWlRo0aac+ePSpUqJBT/759+yogIECvv/66kpKSMqxz2rRp6t+/v7y8vDRy5EhJSvf69+/fXyVKlNCYMWO0fft2zZ49W76+vtq6davKlCmj8ePH69tvv9Xbb7+t6tWrq1u3brcdl9OnT6t27dq6dOmSnn/+eVWpUkWnTp3SkiVLdOXKFbm7u+vIkSNatmyZ2rVrp7Jly+r333/XrFmz1LBhQ+3Zs0eBgYF3HPvnnntOn3zyiZ599lnVr19f69aty3A8syIlJUUtWrRQ3bp19dZbb2nlypUaNWqUbty4obFjx972cZl5zcqVK6fw8HDNnz9fgwcPdnr8/Pnz5e3trTZt2mR6/H7//XfVr19fV65c0YABA1SkSBHNnTtXrVu31pIlS/Tkk0+6NAZ/93OUmd81gKkMAHcUHR1tSDJiYmJu28fHx8cICwtzbI8aNcq4+cdr6tSphiTj3Llzt91HTEyMIcmIjo5Od1/Dhg0NScbMmTMzvK9hw4aO7fXr1xuSjFKlShkJCQmO9sWLFxuSjHfffdfRFhwcbHTv3v1v93mrtH2NHTvW0ZY2TkePHjUMwzDOnj1ruLu7G4899piRkpLi6Pf+++8bkoz//Oc/6Y5v3rx5jrbk5GSjRIkSxtNPP+1o+/jjj418+fIZ33//vVM9M2fONCQZW7ZsuW3NhmEY3bt3N4KDgx3by5YtMyQZb775plO/Z555xrDZbMahQ4cMwzCMnTt3GpKMQYMGOfXr0aOHIckYNWqUo+3KlSvpnnfbtm3pji9tvB5++GHjxo0bTv1vHUvDMIzQ0NAMX5O0vs2bNzdSU1Md7fXq1TNsNpvRp08fR9uNGzeM0qVLp9vPrcfQrVs3I1++fBm+59Oe488//3R6XQ3DMI4ePWrY7Xan90VGYmNjDUlG3759ndqfffbZdLVkNBYZ6d69uyHJ6N+/v1OtLVu2NNzd3Z1+9lx9zWbNmmVIMvbu3etou3btmlG0aFGnn6PMjN+gQYMMSU7v5cuXLxtly5Y1QkJCHGN7u+NP+zlfv369oy2zP0d3+l0DmI2P8oFs4OXldcer8319fSVJX375pVJTU116DrvdrsjIyEz379atm7y9vR3bzzzzjEqWLKlvv/3WpedPs2fPHvXs2VNt2rS54wUza9as0bVr1zRo0CDly/e/XzW9e/dW4cKF031k6eXlpS5duji23d3dVbt2bR05csTR9tlnn6lq1aqqUqWK/vjjD8ft0UcflSStX78+S8fy7bffKn/+/BowYIBT+9ChQ2UYhlasWCFJWrlypaS/ZjdvlnYR3M1uno2+fv26zp8/rwoVKsjX11c//vhjuv69e/fOlnMoe/Xq5XT6SJ06dWQYhnr16uVoy58/v2rVquU0prdKTU3VsmXL1KpVK6dzqtOkPYfdbne8rikpKTp//rzjFJWMjvNmae/BW8d90KBBdz7ITHjxxRedan3xxRd17do1rVmz5raPyexr1r59exUsWFDz5893tK1atUp//PGH472b2fH79ttvVbt2bT388MOO+7y8vPT888/r2LFj2rNnjwtHn7mfI8DK7plgumnTJrVq1UqBgYGy2WxZ/khP+utjvXfeeUeVKlWS3W5XqVKlNG7cuOwvFvecxMREpxB4qw4dOig8PFzPPfecihcvro4dO2rx4sVZCqmlSpXK0oVOFStWdNq22WyqUKHCP1oPMiEhQU899ZRKlSqlefPm3XGt1ri4OElS5cqVndrd3d1Vrlw5x/1pSpcunW5/fn5+unjxomP74MGD+vXXXxUQEOB0q1SpkiTp7NmzWTqeuLg4BQYGpnvtqlat6nQMcXFxypcvn8qWLevUr0KFCun2efXqVb3++uuOc1aLFi2qgIAAXbp0SfHx8en637pPV5UpU8Zp28fHR5IUFBSUrv3mMb3VuXPnlJCQoOrVq9/x+VJTUzV16lRVrFjR6Th/+eWXDI/zZmnjWb58eaf2W98rWZUvXz6VK1fOqS3tvXGn931mXzNfX1+1atVKCxYscLTNnz9fpUqVcvxxlNnxi4uLy/B4b33vZVVmfo4AK7tnzjFNSkrSfffdp549e+qpp55yaR8DBw7U6tWr9c4776hGjRq6cOGCLly4kM2V4l5z8uRJxcfHZxhS0nh4eGjTpk1av369vvnmG61cuVKffvqpHn30Ua1evTpTM2ZZPS80M24XLFNSUjKsqUePHjp9+rR++OEHFS5cOFtrud0YGDdduJKamqoaNWpoypQpGfa9NYSZoX///oqOjtagQYNUr149+fj4yGazqWPHjhn+IZJdr+vtxi+jduNvLgbKjPHjx+vf//63evbsqTfeeEP+/v7Kly+fBg0a5PKnAmbJymvWrVs3ffbZZ9q6datq1Kih5cuXq2/fvk6fCmSnO/2MZiQzP0eAld0zwTQiIsJxgURGkpOTNXLkSC1cuFCXLl1S9erVNWnSJMeVrXv37lVUVJR2797t+Cs2u2YycG/7+OOPJUnNmze/Y798+fKpSZMmatKkiaZMmaLx48dr5MiRWr9+vZo2bZrt3xR18OBBp23DMHTo0CHVrFnT0ebn55fuCnnpr9maW2eeJk6cqGXLlumLL75QlSpV/vb509ad3L9/v9O+rl27pqNHj6pp06ZZORxJUvny5fXzzz+rSZMm2TJewcHBWrNmjS5fvuw0a7pv3z7H/Wn/TU1N1dGjR51mog8dOpRun0uWLFH37t01efJkR9uff/6Z4Thnxd36JrGAgAAVLlxYu3fvvmO/JUuWqHHjxvroo4+c2i9duqSiRYve8bFp43n48GGnWcP9+/e7Xrj++sPlyJEjjllSSTpw4IAk3fEbv7LymrVo0UIBAQGaP3++6tSpoytXrqhr166O+zM7fsHBwRke763vPT8/P0lKV4urM6rS3XsvAa64Zz7K/zsvvviitm3bpkWLFumXX35Ru3bt1KJFC8c/3l999ZXKlSunr7/+WmXLllVISIiee+45ZkxxR+vWrdMbb7yhsmXLqnPnzrftl9H76P7775ckxzJHnp6ektL/A+SqefPmOZ33umTJEp05c8bpD7jy5ctr+/btTkvYfP311+mWlVqzZo1ee+01jRw5Um3bts3U8zdt2lTu7u6aPn2602zNRx99pPj4eJeuwG7fvr1OnTqlDz/8MN19V69eve1V7bfz+OOPKyUlRe+//75T+9SpU2Wz2RxjlfZHx4wZM5z6vffee+n2mT9//nSzU++9995tZ7gyy9PTM9veG3eSL18+tW3bVl999ZV27NiR7v60Y8voOD/77DOdOnXqb58jbVynT5/u1D5t2jQXq/6fm19LwzD0/vvvq0CBAmrSpMltH5OV18zNzU2dOnXS4sWLNWfOHNWoUcPpj73Mjt/jjz+uH374Qdu2bXPcl5SUpNmzZyskJETVqlWTJMfpDps2bXL0S0lJ0ezZs+84DneS3b9rgOx0z8yY3snx48cVHR2t48ePO5YwGTZsmFauXKno6GiNHz9eR44cUVxcnD777DPNmzdPKSkpGjx4sJ555hmtW7fO5COAFaxYsUL79u3TjRs39Pvvv2vdunX67rvvFBwcrOXLl99xkfKxY8dq06ZNatmypYKDg3X27FnNmDFDpUuXdlz8UL58efn6+mrmzJny9vaWp6en6tSp4/LMvb+/vx5++GFFRkbq999/17Rp01ShQgWnJa2ee+45LVmyRC1atFD79u11+PBhffLJJ+nO/evUqZMCAgJUsWJFp/VaJalZs2YZLl0VEBCg4cOHa8yYMWrRooVat26t/fv3a8aMGXrooYecLtDIrK5du2rx4sXq06eP1q9fr/DwcKWkpGjfvn1avHixVq1aleEFJ7fTqlUrNW7cWCNHjtSxY8d03333afXq1fryyy81aNAgxzg8+OCDevrppzVt2jSdP3/esVxU2mzczTNQTzzxhD7++GP5+PioWrVq2rZtm9asWXPHZbUy48EHH1RUVJTefPNNVahQQcWKFXOc15jdxo8fr9WrV6thw4aOZbnOnDmjzz77TJs3b5avr6+eeOIJjR07VpGRkapfv7527dql+fPnp5tpz8j999+vTp06acaMGYqPj1f9+vW1du3aDGegs6JgwYJauXKlunfvrjp16mjFihX65ptvNGLECAUEBNz2cVl9zbp166bp06dr/fr1mjRpUrr7MzN+r776qhYuXKiIiAgNGDBA/v7+mjt3ro4eParPP//ccWpAaGio6tatq+HDh+vChQvy9/fXokWLdOPGDZfHKbt/1wDZyoylAHKaJGPp0qWO7a+//tqQZHh6ejrd3NzcjPbt2xuGYRi9e/c2JBn79+93PC5tiZh9+/bd7UOAhaQt15J2c3d3N0qUKGE0a9bMePfdd52WZEpz63JRa9euNdq0aWMEBgYa7u7uRmBgoNGpUyfjwIEDTo/78ssvjWrVqhlubm5Oy7k0bNjQCA0NzbC+2y0XtXDhQmP48OFGsWLFDA8PD6Nly5ZGXFxcusdPnjzZKFWqlGG3243w8HBjx44d6fZ58/HfektbruZ2y9q8//77RpUqVYwCBQoYxYsXN1544QXj4sWL6Y4ho+O7dXknw/hreZ5JkyYZoaGhht1uN/z8/IwHH3zQGDNmjBEfH5/hGN1pf5cvXzYGDx5sBAYGGgUKFDAqVqxovP32205LLxmGYSQlJRn9+vUz/P39DS8vL6Nt27bG/v37DUnGxIkTHf0uXrxoREZGGkWLFjW8vLyM5s2bG/v27Uu3NNedliHLaCx/++03o2XLloa3t7chyfH63G4/ae/BW5co6969u+Hp6enUpluWTzIMw4iLizO6detmBAQEGHa73ShXrpzRr18/Izk52TCMv5aLGjp0qFGyZEnDw8PDCA8PN7Zt2/a3S42luXr1qjFgwACjSJEihqenp9GqVSvjxIkT/2i5KE9PT+Pw4cPGY489ZhQqVMgoXry4MWrUqHTLWt36HJl9zW4WGhpq5MuXzzh58mSG9//d+BmGYRw+fNh45plnDF9fX6NgwYJG7dq1ja+//jrdvg4fPmw0bdrUsNvtRvHixY0RI0YY3333XYbLRWX25+h2v2sAs9kM4947I9pms2np0qWOjxw//fRTde7cWb/++mu6E8O9vLxUokQJjRo1SuPHj9f169cd9129elWFChXS6tWr1axZs7t5CABygdjYWIWFhemTTz6546kcyHk9evTQkiVL0n0RRE4JCwuTv7+/1q5de1eeD8gr8sRH+WFhYUpJSdHZs2cd33Jxq/DwcN24cUOHDx92fHyX9jFd2knoAPKuq1evpruCftq0acqXL58aNGhgUlUww44dOxQbG8vXeAI54J4JpomJiU7nJx09elSxsbHy9/dXpUqV1LlzZ3Xr1k2TJ09WWFiYzp07p7Vr16pmzZpq2bKlmjZtqgceeEA9e/bUtGnTlJqaqn79+qlZs2ZOV3gCyJveeust7dy5U40bN5abm5tWrFihFStW6Pnnn7fEMlXIebt379bOnTs1efJklSxZUh06dDC7JOCec89clb9jxw6FhYUpLCxMkjRkyBCFhYXp9ddflyRFR0erW7duGjp0qCpXrqy2bdsqJibGsSh1vnz59NVXX6lo0aJq0KCBWrZsqapVq2rRokWmHRMA66hfv74uXLigN954Q0OHDtWBAwc0evRoffDBB2aXhrtkyZIlioyM1PXr17Vw4cI7XvAIwDX35DmmAAAAyH3umRlTAAAA5G4EUwAAAFhCrr74KTU1VadPn5a3tzdfsQYAAGBBhmHo8uXLCgwMdHx5xO3k6mB6+vRproYFAADIBU6cOKHSpUvfsU+uDqbe3t6S/jrQwoULm1wNAAAAbpWQkKCgoCBHbruTXB1M0z6+L1y4MMEUAADAwjJz2iUXPwEAAMASCKYAAACwBIIpAAAALMH0YHrq1Cl16dJFRYoUkYeHh2rUqKEdO3aYXRYAAADuMlMvfrp48aLCw8PVuHFjrVixQgEBATp48KD8/PzMLAsAAAAmMDWYTpo0SUFBQYqOjna0lS1b1sSKAAAAYBZTP8pfvny5atWqpXbt2qlYsWIKCwvThx9+eNv+ycnJSkhIcLoBAADg3mBqMD1y5IiioqJUsWJFrVq1Si+88IIGDBiguXPnZth/woQJ8vHxcdz41icAAIB7h80wDMOsJ3d3d1etWrW0detWR9uAAQMUExOjbdu2peufnJys5ORkx3baNwnEx8ezwD4AAIAFJSQkyMfHJ1N5zdQZ05IlS6patWpObVWrVtXx48cz7G+32x3f8sS3PQEAANxbTA2m4eHh2r9/v1PbgQMHFBwcbFJFAAAAMIupV+UPHjxY9evX1/jx49W+fXv98MMPmj17tmbPnm1mWXcU8uo3Wep/bGLLHKoEAADg3mLqjOlDDz2kpUuXauHChapevbreeOMNTZs2TZ07dzazLAAAAJjA1BlTSXriiSf0xBNPmF0GAAAATGb6V5ICAAAAEsEUAAAAFkEwBQAAgCUQTAEAAGAJBFMAAABYAsEUAAAAlkAwBQAAgCUQTAEAAGAJBFMAAABYAsEUAAAAlkAwBQAAgCUQTAEAAGAJBFMAAABYAsEUAAAAlkAwBQAAgCUQTAEAAGAJBFMAAABYAsEUAAAAlkAwBQAAgCUQTAEAAGAJBFMAAABYAsEUAAAAlkAwBQAAgCUQTAEAAGAJBFMAAABYAsEUAAAAlkAwBQAAgCUQTAEAAGAJBFMAAABYAsEUAAAAlkAwBQAAgCUQTAEAAGAJBFMAAABYAsEUAAAAlkAwBQAAgCUQTAEAAGAJBFMAAABYAsEUAAAAlkAwBQAAgCWYGkxHjx4tm83mdKtSpYqZJQEAAMAkbmYXEBoaqjVr1ji23dxMLwkAAAAmMD0Furm5qUSJEpnqm5ycrOTkZMd2QkJCTpUFAACAu8z0c0wPHjyowMBAlStXTp07d9bx48dv23fChAny8fFx3IKCgu5ipQAAAMhJpgbTOnXqaM6cOVq5cqWioqJ09OhRPfLII7p8+XKG/YcPH674+HjH7cSJE3e5YgAAAOQUUz/Kj4iIcPx/zZo1VadOHQUHB2vx4sXq1atXuv52u112u/1ulggAAIC7xPSP8m/m6+urSpUq6dChQ2aXAgAAgLvMUsE0MTFRhw8fVsmSJc0uBQAAAHeZqcF02LBh2rhxo44dO6atW7fqySefVP78+dWpUyczywIAAIAJTD3H9OTJk+rUqZPOnz+vgIAAPfzww9q+fbsCAgLMLAsAAAAmMDWYLlq0yMynBwAAgIVY6hxTAAAA5F0EUwAAAFgCwRQAAACWQDAFAACAJRBMAQAAYAkEUwAAAFgCwRQAAACWQDAFAACAJRBMAQAAYAkEUwAAAFgCwRQAAACWQDAFAACAJRBMAQAAYAkEUwAAAFgCwRQAAACWQDAFAACAJRBMAQAAYAkEUwAAAFgCwRQAAACWQDAFAACAJRBMAQAAYAkEUwAAAFgCwRQAAACWQDAFAACAJRBMAQAAYAkEUwAAAFgCwRQAAACWQDAFAACAJRBMAQAAYAkEUwAAAFgCwRQAAACWQDAFAACAJRBMAQAAYAkEUwAAAFgCwRQAAACWQDAFAACAJRBMAQAAYAkEUwAAAFiCZYLpxIkTZbPZNGjQILNLAQAAgAksEUxjYmI0a9Ys1axZ0+xSAAAAYBLTg2liYqI6d+6sDz/8UH5+fmaXAwAAAJOYHkz79eunli1bqmnTpn/bNzk5WQkJCU43AAAA3BvczHzyRYsW6ccff1RMTEym+k+YMEFjxozJ4aoAAABgBtNmTE+cOKGBAwdq/vz5KliwYKYeM3z4cMXHxztuJ06cyOEqAQAAcLeYNmO6c+dOnT17Vg888ICjLSUlRZs2bdL777+v5ORk5c+f3+kxdrtddrv9bpcKAACAu8C0YNqkSRPt2rXLqS0yMlJVqlTRK6+8ki6UAgAA4N5mWjD19vZW9erVndo8PT1VpEiRdO0AAAC495l+VT4AAAAgmXxV/q02bNhgdgkAAAAwCTOmAAAAsASCKQAAACyBYAoAAABLIJgCAADAEgimAAAAsASCKQAAACzB5eWiTp48qeXLl+v48eO6du2a031Tpkz5x4UBAAAgb3EpmK5du1atW7dWuXLltG/fPlWvXl3Hjh2TYRh64IEHsrtGAAAA5AEufZQ/fPhwDRs2TLt27VLBggX1+eef68SJE2rYsKHatWuX3TUCAAAgD3ApmO7du1fdunWTJLm5uenq1avy8vLS2LFjNWnSpGwtEAAAAHmDS8HU09PTcV5pyZIldfjwYcd9f/zxR/ZUBgAAgDzFpXNM69atq82bN6tq1ap6/PHHNXToUO3atUtffPGF6tatm901AgAAIA9wKZhOmTJFiYmJkqQxY8YoMTFRn376qSpWrMgV+QAAAHCJS8G0XLlyjv/39PTUzJkzs60gAAAA5E0unWPas2dPzZ07N117QkKCevbs+Y+LAgAAQN7jUjCdM2eO+vbtqwEDBig1NdXRfvXq1QwDKwAAAPB3XP5K0m+++UbffvutmjdvrosXL2ZnTQAAAMiDXA6m1apV03//+19dv35dtWvX1t69e7OzLgAAAOQxLgVTm80mSSpSpIjWrFmjhg0bql69elq+fHm2FgcAAIC8w6Wr8g3D+N8O3Nz0f//3f6pWrZr69u2bbYUBAAAgb3EpmK5fv17+/v5ObUOGDFHNmjW1ZcuWbCkMAAAAeYtLwbRhw4YZtjdt2lRNmzb9RwUBAAAgb3IpmKakpGjOnDlau3atzp4967RklCStW7cuW4oDAABA3uFSMB04cKDmzJmjli1bqnr16o6LoQAAAABXuRRMFy1apMWLF+vxxx/P7noAAACQR7m0XJS7u7sqVKiQ3bUAAAAgD3MpmA4dOlTvvvuu07JRAAAAwD/h0kf5mzdv1vr167VixQqFhoaqQIECTvd/8cUX2VIcAAAA8g6Xgqmvr6+efPLJ7K4FAAAAeZhLwTQ6Ojq76wAAAEAe59I5ppJ048YNrVmzRrNmzdLly5clSadPn1ZiYmK2FQcAAIC8w6UZ07i4OLVo0ULHjx9XcnKymjVrJm9vb02aNEnJycmaOXNmdtcJAACAe5xLM6YDBw5UrVq1dPHiRXl4eDjan3zySa1duzbbigMAAEDe4dKM6ffff6+tW7fK3d3dqT0kJESnTp3KlsIAAACQt7g0Y5qamqqUlJR07SdPnpS3t/c/LgoAAAB5j0vB9LHHHtO0adMc2zabTYmJiRo1ahRfUwoAAACXuPRR/uTJk9W8eXNVq1ZNf/75p5599lkdPHhQRYsW1cKFC7O7RgAAAOQBLgXT0qVL6+eff9aiRYv0yy+/KDExUb169VLnzp2dLoYCAAAAMsulYCpJbm5u6tKlS3bWAgAAgDzMpWA6b968O97frVu3TO0nKipKUVFROnbsmCQpNDRUr7/+uiIiIlwpCwAAALmYS8F04MCBTtvXr1/XlStX5O7urkKFCmU6mJYuXVoTJ05UxYoVZRiG5s6dqzZt2uinn35SaGioK6UBAAAgl3IpmF68eDFd28GDB/XCCy/opZdeyvR+WrVq5bQ9btw4RUVFafv27QRTAACAPMblc0xvVbFiRU2cOFFdunTRvn37svz4lJQUffbZZ0pKSlK9evUy7JOcnKzk5GTHdkJCgsv1AgAAwFpcWsf0dtzc3HT69OksPWbXrl3y8vKS3W5Xnz59tHTpUlWrVi3DvhMmTJCPj4/jFhQUlB1lAwAAwAJcmjFdvny507ZhGDpz5ozef/99hYeHZ2lflStXVmxsrOLj47VkyRJ1795dGzduzDCcDh8+XEOGDHFsJyQkEE4BAADuES4F07Zt2zpt22w2BQQE6NFHH9XkyZOztC93d3dVqFBBkvTggw8qJiZG7777rmbNmpWur91ul91ud6VkAAAAWJxLwTQ1NTW763Da983nkQIAACBvyLaLn1wxfPhwRUREqEyZMrp8+bIWLFigDRs2aNWqVWaWBQAAABO4FExvPs/z70yZMuW29509e1bdunXTmTNn5OPjo5o1a2rVqlVq1qyZK2UBAAAgF3MpmP7000/66aefdP36dVWuXFmSdODAAeXPn18PPPCAo5/NZrvjfj766CNXnh4AAAD3IJeCaatWreTt7a25c+fKz89P0l+L7kdGRuqRRx7R0KFDs7VIAAAA3PtcWsd08uTJmjBhgiOUSpKfn5/efPPNLF+VDwAAAEguBtOEhASdO3cuXfu5c+d0+fLlf1wUAAAA8h6XgumTTz6pyMhIffHFFzp58qROnjypzz//XL169dJTTz2V3TUCAAAgD3DpHNOZM2dq2LBhevbZZ3X9+vW/duTmpl69euntt9/O1gIBAACQN7gUTAsVKqQZM2bo7bff1uHDhyVJ5cuXl6enZ7YWBwAAgLzDpY/y05w5c0ZnzpxRxYoV5enpKcMwsqsuAAAA5DEuBdPz58+rSZMmqlSpkh5//HGdOXNGktSrVy+WigIAAIBLXAqmgwcPVoECBXT8+HEVKlTI0d6hQwetXLky24oDAABA3uHSOaarV6/WqlWrVLp0aaf2ihUrKi4uLlsKAwAAQN7i0oxpUlKS00xpmgsXLshut//jogAAAJD3uBRMH3nkEc2bN8+xbbPZlJqaqrfeekuNGzfOtuIAAACQd7j0Uf5bb72lJk2aaMeOHbp27Zpefvll/frrr7pw4YK2bNmS3TUCAAAgD3BpxrR69eo6cOCAHn74YbVp00ZJSUl66qmn9NNPP6l8+fLZXSMAAADygCzPmF6/fl0tWrTQzJkzNXLkyJyoCQAAAHlQlmdMCxQooF9++SUnagEAAEAe5tJH+V26dNFHH32U3bUAAAAgD3Pp4qcbN27oP//5j9asWaMHH3xQnp6eTvdPmTIlW4oDAABA3pGlYHrkyBGFhIRo9+7deuCBByRJBw4ccOpjs9myrzoAAADkGVkKphUrVtSZM2e0fv16SX99Ben06dNVvHjxHCkOAAAAeUeWzjE1DMNpe8WKFUpKSsrWggAAAJA3uXTxU5pbgyoAAADgqiwFU5vNlu4cUs4pBQAAQHbI0jmmhmGoR48estvtkqQ///xTffr0SXdV/hdffJF9FQIAACBPyFIw7d69u9N2ly5dsrUYAAAA5F1ZCqbR0dE5VQcAAADyuH908RMAAACQXQimAAAAsASCKQAAACyBYAoAAABLIJgCAADAEgimAAAAsASCKQAAACyBYAoAAABLIJgCAADAEgimAAAAsASCKQAAACyBYAoAAABLIJgCAADAEkwNphMmTNBDDz0kb29vFStWTG3bttX+/fvNLAkAAAAmMTWYbty4Uf369dP27dv13Xff6fr163rssceUlJRkZlkAAAAwgZuZT75y5Uqn7Tlz5qhYsWLauXOnGjRokK5/cnKykpOTHdsJCQk5XiMAAADuDkudYxofHy9J8vf3z/D+CRMmyMfHx3ELCgq6m+UBAAAgB1kmmKampmrQoEEKDw9X9erVM+wzfPhwxcfHO24nTpy4y1UCAAAgp5j6Uf7N+vXrp927d2vz5s237WO322W32+9iVQAAALhbLBFMX3zxRX399dfatGmTSpcubXY5AAAAMIGpwdQwDPXv319Lly7Vhg0bVLZsWTPLAQAAgIlMDab9+vXTggUL9OWXX8rb21u//fabJMnHx0ceHh5mlgYAAIC7zNSLn6KiohQfH69GjRqpZMmSjtunn35qZlkAAAAwgekf5QMAAACShZaLAgAAQN5GMAUAAIAlEEwBAABgCQRTAAAAWALBFAAAAJZAMAUAAIAlEEwBAABgCQRTAAAAWALBFAAAAJZAMAUAAIAlEEwBAABgCQRTAAAAWALBFAAAAJZAMAUAAIAlEEwBAABgCQRTAAAAWIKb2QXgf0Je/SbTfY9NbJmDlQAAANx9zJgCAADAEgimAAAAsASCKQAAACyBYAoAAABLIJgCAADAEgimAAAAsASCKQAAACyBYAoAAABLIJgCAADAEgimAAAAsASCKQAAACyBYAoAAABLIJgCAADAEgimAAAAsASCKQAAACyBYAoAAABLIJgCAADAEgimAAAAsASCKQAAACyBYAoAAABLIJgCAADAEkwNpps2bVKrVq0UGBgom82mZcuWmVkOAAAATGRqME1KStJ9992nDz74wMwyAAAAYAFuZj55RESEIiIizCwBAAAAFmFqMM2q5ORkJScnO7YTEhJMrAYAAADZKVdd/DRhwgT5+Pg4bkFBQWaXBAAAgGySq4Lp8OHDFR8f77idOHHC7JIAAACQTXLVR/l2u112u93sMgAAAJADctWMKQAAAO5dps6YJiYm6tChQ47to0ePKjY2Vv7+/ipTpoyJlQEAAOBuMzWY7tixQ40bN3ZsDxkyRJLUvXt3zZkzx6SqAAAAYAZTg2mjRo1kGIaZJQAAAMAiOMcUAAAAlkAwBQAAgCUQTAEAAGAJBFMAAABYAsEUAAAAlkAwBQAAgCUQTAEAAGAJBFMAAABYAsEUAAAAlkAwBQAAgCWY+pWkuDtCXv0mS/2PTWyZQ5UAAADcHjOmAAAAsASCKQAAACyBYAoAAABLIJgCAADAEgimAAAAsASCKQAAACyBYAoAAABLIJgCAADAEgimAAAAsASCKQAAACyBYAoAAABLIJgCAADAEgimAAAAsAQ3swtA7hby6jc5tu9jE1vm2L4BAID1MGMKAAAASyCYAgAAwBIIpgAAALAEgikAAAAsgWAKAAAASyCYAgAAwBIIpgAAALAEgikAAAAsgQX2YVlZWbyfxfgBAMj9mDEFAACAJRBMAQAAYAl8lI97Qk597J+V/WZ13wAAwBkzpgAAALAEZkyR52R1FjSn9s3sKgAAziwxY/rBBx8oJCREBQsWVJ06dfTDDz+YXRIAAADuMtNnTD/99FMNGTJEM2fOVJ06dTRt2jQ1b95c+/fvV7FixcwuD8gxzK4CAODM9GA6ZcoU9e7dW5GRkZKkmTNn6ptvvtF//vMfvfrqqyZXB1hDTp5+kBUEZABATjI1mF67dk07d+7U8OHDHW358uVT06ZNtW3btnT9k5OTlZyc7NiOj4+XJCUkJOR8sf9favKVLPXPSm1Z2XdO7Ten943crczgz8wuwVJ2j2ludgkAYHlpucIwjL/ta2ow/eOPP5SSkqLixYs7tRcvXlz79u1L13/ChAkaM2ZMuvagoKAcq/Gf8pmWu/ab0/sG7iX8rABA5l2+fFk+Pj537GP6R/lZMXz4cA0ZMsSxnZqaqgsXLqhIkSKy2WwmVpY9EhISFBQUpBMnTqhw4cJml5MrMGauYdyyjjHLOsYs6xgz1zBuWXc3x8wwDF2+fFmBgYF/29fUYFq0aFHlz59fv//+u1P777//rhIlSqTrb7fbZbfbndp8fX1zskRTFC5cmB+sLGLMXMO4ZR1jlnWMWdYxZq5h3LLubo3Z382UpjF1uSh3d3c9+OCDWrt2raMtNTVVa9euVb169UysDAAAAHeb6R/lDxkyRN27d1etWrVUu3ZtTZs2TUlJSY6r9AEAAJA3mB5MO3TooHPnzun111/Xb7/9pvvvv18rV65Md0FUXmC32zVq1Kh0pyvg9hgz1zBuWceYZR1jlnWMmWsYt6yz6pjZjMxcuw8AAADkMEt8JSkAAABAMAUAAIAlEEwBAABgCQRTAAAAWALB1AI2bdqkVq1aKTAwUDabTcuWLTO7JMubMGGCHnroIXl7e6tYsWJq27at9u/fb3ZZlhYVFaWaNWs6FlOuV6+eVqxYYXZZucrEiRNls9k0aNAgs0uxtNGjR8tmszndqlSpYnZZlnfq1Cl16dJFRYoUkYeHh2rUqKEdO3aYXZZlhYSEpHuf2Ww29evXz+zSLCslJUX//ve/VbZsWXl4eKh8+fJ64403MvUd9neL6ctFQUpKStJ9992nnj176qmnnjK7nFxh48aN6tevnx566CHduHFDI0aM0GOPPaY9e/bI09PT7PIsqXTp0po4caIqVqwowzA0d+5ctWnTRj/99JNCQ0PNLs/yYmJiNGvWLNWsWdPsUnKF0NBQrVmzxrHt5sY/N3dy8eJFhYeHq3HjxlqxYoUCAgJ08OBB+fn5mV2aZcXExCglJcWxvXv3bjVr1kzt2rUzsSprmzRpkqKiojR37lyFhoZqx44dioyMlI+PjwYMGGB2eZIIppYQERGhiIgIs8vIVVauXOm0PWfOHBUrVkw7d+5UgwYNTKrK2lq1auW0PW7cOEVFRWn79u0E07+RmJiozp0768MPP9Sbb75pdjm5gpubW4ZfLY2MTZo0SUFBQYqOjna0lS1b1sSKrC8gIMBpe+LEiSpfvrwaNmxoUkXWt3XrVrVp00YtW7aU9Nes88KFC/XDDz+YXNn/8FE+7gnx8fGSJH9/f5MryR1SUlK0aNEiJSUl8fW/mdCvXz+1bNlSTZs2NbuUXOPgwYMKDAxUuXLl1LlzZx0/ftzskixt+fLlqlWrltq1a6dixYopLCxMH374odll5RrXrl3TJ598op49e8pms5ldjmXVr19fa9eu1YEDByRJP//8szZv3mypyTFmTJHrpaamatCgQQoPD1f16tXNLsfSdu3apXr16unPP/+Ul5eXli5dqmrVqpldlqUtWrRIP/74o2JiYswuJdeoU6eO5syZo8qVK+vMmTMaM2aMHnnkEe3evVve3t5ml2dJR44cUVRUlIYMGaIRI0YoJiZGAwYMkLu7u7p37252eZa3bNkyXbp0ST169DC7FEt79dVXlZCQoCpVqih//vxKSUnRuHHj1LlzZ7NLcyCYItfr16+fdu/erc2bN5tdiuVVrlxZsbGxio+P15IlS9S9e3dt3LiRcHobJ06c0MCBA/Xdd9+pYMGCZpeTa9w8+1KzZk3VqVNHwcHBWrx4sXr16mViZdaVmpqqWrVqafz48ZKksLAw7d69WzNnziSYZsJHH32kiIgIBQYGml2KpS1evFjz58/XggULFBoaqtjYWA0aNEiBgYGWeZ8RTJGrvfjii/r666+1adMmlS5d2uxyLM/d3V0VKlSQJD344IOKiYnRu+++q1mzZplcmTXt3LlTZ8+e1QMPPOBoS0lJ0aZNm/T+++8rOTlZ+fPnN7HC3MHX11eVKlXSoUOHzC7FskqWLJnuD8SqVavq888/N6mi3CMuLk5r1qzRF198YXYplvfSSy/p1VdfVceOHSVJNWrUUFxcnCZMmEAwBf4JwzDUv39/LV26VBs2bOAiARelpqYqOTnZ7DIsq0mTJtq1a5dTW2RkpKpUqaJXXnmFUJpJiYmJOnz4sLp27Wp2KZYVHh6ebsm7AwcOKDg42KSKco/o6GgVK1bMcUEPbu/KlSvKl8/58qL8+fMrNTXVpIrSI5haQGJiotNMwtGjRxUbGyt/f3+VKVPGxMqsq1+/flqwYIG+/PJLeXt767fffpMk+fj4yMPDw+TqrGn48OGKiIhQmTJldPnyZS1YsEAbNmzQqlWrzC7Nsry9vdOdt+zp6akiRYpwPvMdDBs2TK1atVJwcLBOnz6tUaNGKX/+/OrUqZPZpVnW4MGDVb9+fY0fP17t27fXDz/8oNmzZ2v27Nlml2Zpqampio6OVvfu3VmSLBNatWqlcePGqUyZMgoNDdVPP/2kKVOmqGfPnmaX9j8GTLd+/XpDUrpb9+7dzS7NsjIaL0lGdHS02aVZVs+ePY3g4GDD3d3dCAgIMJo0aWKsXr3a7LJynYYNGxoDBw40uwxL69Chg1GyZEnD3d3dKFWqlNGhQwfj0KFDZpdleV999ZVRvXp1w263G1WqVDFmz55tdkmWt2rVKkOSsX//frNLyRUSEhKMgQMHGmXKlDEKFixolCtXzhg5cqSRnJxsdmkONsOw0HL/AAAAyLNYxxQAAACWQDAFAACAJRBMAQAAYAkEUwAAAFgCwRQAAACWQDAFAACAJRBMAQAAYAkEUwAAAFgCwRSA5TRq1EiDBg3KkX03aNBACxYsyJF9Z6eQkBBNmzbN7DLuimvXrikkJEQ7duwwuxQAJiOYAsgzli9frt9//10dO3Z0tM2ePVuNGjVS4cKFZbPZdOnSJfMKzANGjx6t+++/36nN3d1dw4YN0yuvvGJOUQAsg2AKIM+YPn26IiMjlS/f/371XblyRS1atNCIESNc3m+jRo00Z86cbKgw7+rcubM2b96sX3/91exSAJiIYArA8i5evKhu3brJz89PhQoVUkREhA4ePOjU58MPP1RQUJAKFSqkJ598UlOmTJGvr6/j/nPnzmndunVq1aqV0+MGDRqkV199VXXr1r0bhyLpryD74osv6sUXX5SPj4+KFi2qf//73zIM47aPmTJlimrUqCFPT08FBQWpb9++SkxMlCQlJSWpcOHCWrJkidNjli1bJk9PT12+fFmSdPLkSXXq1En+/v7y9PRUrVq19N///tfRPyoqSuXLl5e7u7sqV66sjz/+2HHfsWPHZLPZFBsb62i7dOmSbDabNmzYIEnasGGDbDab1q5dq1q1aqlQoUKqX7++9u/fL0maM2eOxowZo59//lk2m002m80R6P38/BQeHq5Fixa5PK4Acj+CKQDL69Gjh3bs2KHly5dr27ZtMgxDjz/+uK5fvy5J2rJli/r06aOBAwcqNjZWzZo107hx45z2sXnzZhUqVEhVq1Y14xDSmTt3rtzc3PTDDz/o3Xff1ZQpU/R///d/t+2fL18+TZ8+Xb/++qvmzp2rdevW6eWXX5YkeXp6qmPHjoqOjnZ6THR0tJ555hl5e3srMTFRDRs21KlTp7R8+XL9/PPPevnll5WamipJWrp0qQYOHKihQ4dq9+7d+te//qXIyEitX78+y8c2cuRITZ48WTt27JCbm5t69uwpSerQoYOGDh2q0NBQnTlzRmfOnFGHDh0cj6tdu7a+//77LD8fgHuHm9kFAMCdHDx4UMuXL9eWLVtUv359SdL8+fMVFBSkZcuWqV27dnrvvfcUERGhYcOGSZIqVaqkrVu36uuvv3bsJy4uTsWLF3f6GN9MQUFBmjp1qmw2mypXrqxdu3Zp6tSp6t27d4b9b74YLCQkRG+++ab69OmjGTNmSJKee+451a9fX2fOnFHJkiV19uxZffvtt1qzZo0kacGCBTp37pxiYmLk7+8vSapQoYJjn++884569Oihvn37SpKGDBmi7du365133lHjxo2zdGzjxo1Tw4YNJUmvvvqqWrZsqT///FMeHh7y8vKSm5ubSpQoke5xgYGBiouLy9JzAbi3WOM3NADcxt69e+Xm5qY6deo42ooUKaLKlStr7969kqT9+/erdu3aTo+7dfvq1asqWLBgttQ0fvx4eXl5OW7ff/+9+vTp49R2/PjxO+6jbt26stlsju169erp4MGDSklJybD/mjVr1KRJE5UqVUre3t7q2rWrzp8/rytXrkj663hDQ0M1d+5cSdInn3yi4OBgNWjQQJIUGxursLAwRyi91d69exUeHu7UFh4e7hjjrKhZs6bj/0uWLClJOnv27N8+zsPDw3E8APImgimAPKFo0aK6ePFituyrT58+io2Nddxq1aqlsWPHOrUFBgZmy3NJf53f+cQTT6hmzZr6/PPPtXPnTn3wwQeS/lpqKc1zzz3nOGczOjpakZGRjvDr4eHxj2pIm2m++TzYtFMpblWgQAHH/6c9f9opA3dy4cIFBQQE/JMyAeRyBFMAlla1alXduHHD6SKd8+fPa//+/apWrZokqXLlyoqJiXF63K3bYWFh+u2337IlnPr7+6tChQqOm4eHh4oVK+bU5uZ25zOlbj4eSdq+fbsqVqyo/Pnzp+u7c+dOpaamavLkyapbt64qVaqk06dPp+vXpUsXxcXFafr06dqzZ4+6d+/uuK9mzZqKjY3VhQsXMqynatWq2rJli1Pbli1bHGOcFhjPnDnjuP/mC6Eyy93d/bazwrt371ZYWFiW9wng3kEwBWBpFStWVJs2bdS7d29t3rxZP//8s7p06aJSpUqpTZs2kqT+/fvr22+/1ZQpU3Tw4EHNmjVLK1ascPqoPCwsTEWLFk0Xvn777TfFxsbq0KFDkqRdu3bdMcBll+PHj2vIkCHav3+/Fi5cqPfee08DBw7MsG+FChV0/fp1vffeezpy5Ig+/vhjzZw5M10/Pz8/PfXUU3rppZf02GOPqXTp0o77OnXqpBIlSqht27basmWLjhw5os8//1zbtm2TJL300kuaM2eOoqKidPDgQU2ZMkVffPGF47xdDw8P1a1bVxMnTtTevXu1ceNGvfbaa1k+7pCQEB09elSxsbH6448/lJyc7Ljv+++/12OPPZblfQK4hxgAYDENGzY0Bg4c6Ni+cOGC0bVrV8PHx8fw8PAwmjdvbhw4cMDpMbNnzzZKlSpleHh4GG3btjXefPNNo0SJEk59Xn75ZaNjx45ObaNGjTIkpbtFR0dnqd6s9u/bt6/Rp08fo3Dhwoafn58xYsQIIzU11dEnODjYmDp1qmN7ypQpRsmSJR3HP2/ePEOScfHiRad9r1271pBkLF68ON3zHjt2zHj66aeNwoULG4UKFTJq1apl/Pe//3XcP2PGDKNcuXJGgQIFjEqVKhnz5s1zevyePXuMevXqGR4eHsb9999vrF692pBkrF+/3jAMw1i/fn26mn766SdDknH06FHDMAzjzz//NJ5++mnD19fXaZy3bt1q+Pr6GleuXMn0OAK499gM4w4L5wFALtW7d2/t27fPafmh3377TaGhofrxxx8VHBxsWm2NGjXS/fffnyNfOfrxxx9r8ODBOn36tNzd3bN9/zmlQ4cOuu+++/7RFx0AyP1YLgrAPeGdd95Rs2bN5OnpqRUrVmju3LmOpZTSlChRQh999JGOHz9uajDNCVeuXNGZM2c0ceJE/etf/8pVofTatWuqUaOGBg8ebHYpAEzGjCmAe0L79u21YcMGXb58WeXKlVP//v3Vp08fs8vKUE7MmI4ePVrjxo1TgwYN9OWXX8rLyyvb9g0AdwvBFAAAAJbAVfkAAACwBIIpAAAALIFgCgAAAEsgmAIAAMASCKYAAACwBIIpAAAALIFgCgAAAEsgmAIAAMAS/h/ztmrMFVPcxwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "\n",
+    "plt.figure(figsize=(8,4))\n",
+    "plt.hist(np.log1p(df_hist[\"playcount\"]), bins=50)\n",
+    "plt.title(\"Distribuzione logaritmica di playcount\")\n",
+    "plt.xlabel(\"log(1 + playcount)\")\n",
+    "plt.ylabel(\"Frequenza\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53a8c97d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006077,
+     "end_time": "2026-04-11T16:02:46.689373+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:46.683296+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Osservazioni\n",
+    "\n",
+    "- La trasformazione logaritmica rende la distribuzione più leggibile\n",
+    "- Si evidenzia una distribuzione continua con coda lunga (long tail)\n",
+    "- I valori elevati risultano meno compressi rispetto alla scala lineare\n",
+    "\n",
+    "La presenza di una long tail indica che:\n",
+    "- pochi utenti ascoltano alcune tracce molto frequentemente\n",
+    "- la maggior parte delle interazioni è caratterizzata da pochi ascolti"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "952fd414",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T16:02:46.703539Z",
+     "iopub.status.busy": "2026-04-11T16:02:46.702584Z",
+     "iopub.status.idle": "2026-04-11T16:02:49.447827Z",
+     "shell.execute_reply": "2026-04-11T16:02:49.446784Z"
+    },
+    "papermill": {
+     "duration": 2.754549,
+     "end_time": "2026-04-11T16:02:49.449873+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:46.695324+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfsAAAGJCAYAAACNYZoYAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAALYdJREFUeJzt3Xd8lFW+x/HvJCEVQpFUhYQmVYqgGKQKK13ZRV8KLosoNmRtiAjuCnq94uouigpcdHcJyl1cpekKKjWIgigsRUCRDhdCkZIEqUl+9w9fM5shE0gwjcPn/XrNKzPnOc95zjnzTL5TnmfGY2YmAADgrKCy7gAAAChZhD0AAI4j7AEAcBxhDwCA4wh7AAAcR9gDAOA4wh4AAMcR9gAAOI6wBwDAcYQ9UEo8Ho/GjBlTZtu/++67lZyc7FdW3H0KtA0AZY+wxyUvNTVVHo/H7xIbG6tOnTrpk08+Kevu/WKbNm3SmDFjtHPnzrLuCgph4sSJSk1NLetuAH5CyroDQHF5/vnnVatWLZmZDhw4oNTUVPXo0UP/+te/1KtXr7Lu3kXbtGmTnnvuOXXs2LHYXzWfPHlSISH8GyhOEydOVPXq1XX33XeXdVcAHx7lcEb37t3VqlUr3+17771XcXFxmj59+iUd9iUpPDy8rLsAoBTwNj6cVaVKFUVEROR75frTTz9p2LBhqlGjhsLCwlS/fn39+c9/lvcHIE+ePKkGDRqoQYMGOnnypG+9I0eOKCEhQW3atFFOTo6knz+jrlixorZv366uXbsqKipKiYmJev7551WYH5Rcs2aNunfvrujoaFWsWFGdO3fWV1995Vuempqq22+/XZLUqVMn38cUaWlp5213zpw5atKkicLDw9WkSRPNnj07YL3CfGaflpYmj8ejf/7znxo1apTi4+MVFRWlW265RXv27LngGP/85z+rTZs2uuKKKxQREaGWLVtqxowZfnU6dOigZs2aBVy/fv366tq1q+92bm6uxo8fr2uuuUbh4eGKiYlRt27dtGrVKl+d7Oxs/dd//Zfq1KmjsLAwJScna9SoUTp9+nShxp+cnOz3ytz7UdGXX36pJ554QjExMYqKitKvf/1rHTp0yG+9jRs3aunSpb77qmPHjhecI6CkEfZwRkZGhn788UcdOnRIGzdu1EMPPaTjx4/rt7/9ra+OmemWW27Rq6++qm7dumncuHGqX7++hg8frieeeEKSFBERoalTp2rr1q165plnfOs+/PDDysjIUGpqqoKDg33lOTk56tatm+Li4vTyyy+rZcuWGj16tEaPHn3e/m7cuFHt2rXTunXr9NRTT+mPf/yjduzYoY4dO2rlypWSpPbt2+uRRx6RJI0aNUrvvvuu3n33XTVs2LDAdufPn6++ffvK4/Fo7Nix6tOnjwYNGuQXhhfjv//7vzV37lyNGDFCjzzyiBYsWKAuXbr4PSEKZPz48WrRooWef/55vfjiiwoJCdHtt9+uuXPn+uoMGDBA69ev14YNG/zW/eabb/TDDz/43Yf33nuvHnvsMdWoUUN/+tOf9PTTTys8PNzvSdLgwYP17LPP6tprr9Wrr76qDh06aOzYsbrzzjt/0Rz8/ve/17p16zR69Gg99NBD+te//qWhQ4f6lr/22mu66qqr1KBBA999lXcfAsqMAZe4KVOmmKR8l7CwMEtNTfWrO2fOHJNkL7zwgl/5bbfdZh6Px7Zu3eorGzlypAUFBdnnn39uH3zwgUmy1157zW+9gQMHmiT7/e9/7yvLzc21nj17WmhoqB06dMhXLslGjx7tu92nTx8LDQ21bdu2+cr27dtnlSpVsvbt2/vKvNtesmRJoeajefPmlpCQYMeOHfOVzZ8/3yRZUlKSX91z+xTIkiVLTJJdeeWVlpmZ6St///33TZKNHz/eVzZw4MB82zhx4oTf7TNnzliTJk3spptu8pUdO3bMwsPDbcSIEX51H3nkEYuKirLjx4+bmdnixYtNkj3yyCP5+pmbm2tmZmvXrjVJNnjwYL/lTz75pEmyxYsXX3D8SUlJNnDgQN9t7z7WpUsX33bMzB5//HELDg72m+vGjRtbhw4d8rUJlCVe2cMZEyZM0IIFC7RgwQJNmzZNnTp10uDBgzVr1ixfnXnz5ik4ONj3atlr2LBhMjO/o/fHjBmjxo0ba+DAgRoyZIg6dOiQbz2vvK/uPB6Phg4dqjNnzmjhwoUB6+fk5Gj+/Pnq06ePateu7StPSEhQ//799cUXXygzM7PIc5Cenq61a9dq4MCBqly5sq/8V7/6lRo1alTk9vL63e9+p0qVKvlu33bbbUpISNC8efPOu15ERITv+tGjR5WRkaF27drp3//+t6+8cuXKuvXWWzV9+nTfxx85OTn65z//qT59+igqKkqSNHPmTHk8noDvmng8Hkny9cf7To3XsGHDJMnvHYWiuv/++33bkaR27dopJydHu3btuug2gdJA2MMZ119/vbp06aIuXbrorrvu0ty5c9WoUSNf8ErSrl27lJiY6Bdaknxvi+f9px0aGqq///3v2rFjh7KysjRlyhS/f/ReQUFBfoEtSVdffbUkFXi63KFDh3TixAnVr18/37KGDRsqNze3UJ+Hn8vb/3r16uVbFmhbRXFumx6PR3Xr1r3gKYEff/yxbrjhBoWHh6tatWqKiYnRpEmTlJGR4Vfvd7/7nXbv3q1ly5ZJkhYuXKgDBw5owIABvjrbtm1TYmKiqlWrVuD2du3apaCgINWtW9evPD4+XlWqVPlFwVyzZk2/21WrVpX085MYoDwj7OGsoKAgderUSenp6dqyZctFtfHZZ59Jkk6dOnXRbVzOli1bpltuuUXh4eGaOHGi5s2bpwULFqh///75DmDs2rWr4uLiNG3aNEnStGnTFB8fry5dulzUtgM9MSss7wGY58p7rEZe544FKG8IezgtOztbknT8+HFJUlJSkvbt26esrCy/et9//71vudf69ev1/PPPa9CgQWrRooUGDx6c79Wo9PPR4du3b/cr++GHHySpwPPiY2JiFBkZqc2bN+db9v333ysoKEg1atSQVLTQ8vY/0BOTQNsqinPbNDNt3br1vOf+z5w5U+Hh4frss890zz33qHv37gWGd3BwsPr3768ZM2bo6NGjmjNnjvr16+cXsHXq1NG+fft05MiRAreZlJSk3NzcfP09cOCAjh075ncfV61aVceOHfOrd+bMGaWnpxfY/oX8kicZQEkh7OGss2fPav78+QoNDfW9Td+jRw/l5OTozTff9Kv76quvyuPxqHv37r517777biUmJmr8+PFKTU3VgQMH9PjjjwfcVt72zExvvvmmKlSooM6dOwesHxwcrJtvvlkffvih39vgBw4c0D/+8Q+1bdtW0dHRkuT7vPrcUAokISFBzZs319SpU/2emCxYsECbNm264Prn88477/g9SZoxY4bS09N9cxZIcHCwPB6P3yvlnTt3as6cOQHrDxgwQEePHtUDDzyQ70wKSerbt6/MTM8991y+db2vrnv06CHp5yPj8xo3bpwkqWfPnr6yOnXq6PPPP/er99ZbbxX4yr4woqKiCnVfAaWJL9WBMz755BPfK/SDBw/qH//4h7Zs2aKnn37aF5y9e/dWp06d9Mwzz2jnzp1q1qyZ5s+frw8//FCPPfaY6tSpI0l64YUXtHbtWi1atEiVKlVS06ZN9eyzz+oPf/iDbrvtNl+gSD9/Mc2nn36qgQMHqnXr1vrkk080d+5cjRo1SjExMQX294UXXtCCBQvUtm1bDRkyRCEhIZo8ebJOnz6tl19+2VevefPmCg4O1p/+9CdlZGQoLCxMN910k2JjYwO2O3bsWPXs2VNt27bVPffcoyNHjuiNN95Q48aNfe9wXIxq1aqpbdu2GjRokA4cOKDXXntNdevW1X333VfgOj179tS4cePUrVs39e/fXwcPHtSECRNUt25drV+/Pl/9Fi1aqEmTJvrggw/UsGFDXXvttX7LO3XqpAEDBuj111/Xli1b1K1bN+Xm5mrZsmXq1KmThg4dqmbNmmngwIF66623dOzYMXXo0EFff/21pk6dqj59+qhTp06+9gYPHqwHH3xQffv21a9+9SutW7dOn332mapXr37R89SyZUtNmjRJL7zwgurWravY2FjddNNNF90eUCzK7kQAoHgEOvUuPDzcmjdvbpMmTfI7VcrMLCsryx5//HFLTEy0ChUqWL169eyVV17x1Vu9erWFhIT4nU5nZpadnW3XXXedJSYm2tGjR83s51PNoqKibNu2bXbzzTdbZGSkxcXF2ejRoy0nJ8dvfQU4zevf//63de3a1SpWrGiRkZHWqVMnW758eb4xvv3221a7dm0LDg4u1Gl4M2fOtIYNG1pYWJg1atTIZs2aFfC0uEB9Opf31Lvp06fbyJEjLTY21iIiIqxnz562a9cuv7qBtvG3v/3N6tWrZ2FhYdagQQObMmWKjR492gr69/Pyyy+bJHvxxRcDLs/OzrZXXnnFGjRoYKGhoRYTE2Pdu3e31atX++qcPXvWnnvuOatVq5ZVqFDBatSoYSNHjrRTp075tZWTk2MjRoyw6tWrW2RkpHXt2tW2bt1a4Kl333zzTcC5yXt/7N+/33r27GmVKlUySZyGh3LBY8aRJcDFuvvuuzVjxoxf9Iq5vEtLS1OnTp30wQcf6Lbbbivx7Y0fP16PP/64du7cme/odwAXh8/sAZQbZqa//e1v6tChA0EPFCM+swdQ5n766Sd99NFHWrJkib799lt9+OGHZd0lwCmEPYAyd+jQIfXv319VqlTRqFGjdMstt5R1lwCn8Jk9AACO4zN7AAAcR9gDAOC4Uv/MPjc3V/v27VOlSpX4WkkAAIrAzJSVlaXExEQFBRX+9Xqph/2+fft83/kNAACKbs+ePbrqqqsKXb/Uw97706J79uzxfYUpAAC4sMzMTNWoUSPfz3RfSKmHvfet++joaMIeAICLUNSPwTlADwAAxxH2AAA4jrAHAMBxhD0AAI4j7AEAcBxhDwCA4wh7AAAcR9gDAOA4wh4AAMcR9gAAOI6wBwDAcYQ9AACOI+wBAHAcYQ8AgOMIewAAHEfYAwDgOMIeAADHEfYAADiOsAcAwHGEPQAAjiPsAQBwHGEPAIDjCHsAABxH2AMA4DjCHgAAxxH2AAA4jrAHAMBxhD0AAI4j7AEAcBxhDwCA4wh7AAAcR9gDAOA4wh4AAMcR9gAAOI6wBwDAcYQ9AACOI+wBAHAcYQ8AgOMIewAAHEfYAwDgOMIeAADHEfYAADiOsAcAwHGEPQAAjiPsAQBwHGEPAIDjCHsAABxH2AMA4DjCHgAAxxH2AAA4jrAHAMBxhD0AAI4j7AEAcBxhDwCA4wh7AAAcR9gDAOA4wh4AAMcR9gAAOI6wBwDAcYQ9AACOI+wBAHAcYQ8AgOMIewAAHEfYAwDgOMIeAADHEfYAADiOsAcAwHGEPQAAjiPsAQBwHGEPAIDjCHsAABxH2AMA4DjCHgAAxxH2AAA4jrAHAMBxhD0AAI4j7AEAcBxhDwCA4wh7AAAcR9gDAOA4wh4AAMcR9gAAOI6wBwDAcYQ9AACOI+wBAHAcYQ8AgOMIewAAHEfYAwDgOMIeAADHEfYAADiOsAcAwHGEPQAAjiPsAQBwHGEPAIDjCHsAABxH2AMA4DjCHgAAxxH2AAA4jrAHAMBxhD0AAI4j7AEAcBxhDwCA4wh7AAAcR9gDAOA4wh4AAMcR9gAAOI6wBwDAcYQ9AACOI+wBAHAcYQ8AgOMIewAAHEfYAwDgOMIeAADHEfYAADiOsAcAwHGEPQAAjiPsAQBwHGEPAIDjCHsAABxH2AMA4DjCHgAAxxH2AAA4jrAHAMBxhD0AAI4j7AEAcBxhDwCA4wh7AAAc50zYf//992XdBQAAyiUnwv7zeR/ovQeba9knH5R1VwAAKHecCPvDOzdqTMcw/bhjY1l3BQCAcseJsAcAAAUj7AEAcBxhDwCA4wh7AAAcR9gDAOA4wh4AAMcR9gAAOI6wBwDAcU6E/YkTP/n9BQAA/+FE2G/btt3vLwAA+A8nwh4AABSMsAcAwHGEPQAAjiPsAQBwHGEPAIDjCHsAABwXUtYd+KU8Ho9axAfp2Qcqas6cORr9P56y7tIv5vF4ZGZ+t4OCghQWFqYzZ85IkoKDgxUTE6Pjx48rJydHp06dUnh4uLKzsxUSEqKQkBBFRUUpMzNTFStWVI8ePdS7d2+9//772rlzp2rWrKnmzZvr6NGj2rNnj3Jzc33bCwoK0lVXXaXMzEyZmYKDg3Xddddp//79WrhwoY4eParExETVr19fe/fu1cGDB1WxYkW1b99eQ4cOVXBwsJYtW6b09HQlJCSoXbt2kqS0tDSlpaVJkjp27Kh27dpp2bJlfmUdO3ZUcHBwoeYpJycn33a86545c0YTJ07Utm3bVKdOHQ0ZMkShoaEXXF+Sli1bpr179+rQoUOKiYnRlVdeqTZt2mj58uX5tuVtY8+ePVq5cqXMTPXq1dMDDzyglStXFlh/79692r9/v44cOaKgoKBCjf3c/hbUp6LKycnJd98U1JfzzXlJKM4xl3bfcfkql/uaFdHSpUutV69elpCQYJJs9uzZRVo/IyPDJFlGRkZRN52PJJNkLeKDzEZHW4v4IF8Zl7K5eDwei46O9iuLjY3NV+ate25ZbGyszZw584L3/cyZMy05Odlv3eTkZJs5c6YNHz7cQkJC/JaFhITY8OHDz7t+TEyMxcbGBhzXue0lJyfb8OHD87VR0KUw9WNiYgoce6D+BupTYebu3HYDjTlQX8435yWhOMdc2n3H5auk97WLzdAih/28efPsmWeesVmzZplUdmGfdyIJ+7K9RERE5Cu76667LCsry8aOHesra9CggS1atMjGjBnjV3fMmDG2aNEia9u2rUk/Pwk43wNj5syZ5vF4rHfv3rZixQrLysqyFStWWO/evX1txsXF2dtvv23p6en29ttvW1xcnEmy4cOHB1w/bz8lWffu3e3tt9+2Fi1amCSrXLmyeTwemzZtmq1YscJatWplkiw+Pt6kn8Px6aeftmbNmvmF0qOPPupXv06dOr4nOU2bNrWUlBSTZA0bNvRtO1DI5u3vtGnTfGPM26fevXtfcO4CtSvJ2rZta4sWLfK7H/L25XxzXpRtFlagMXs8Ht/9WJQxl3bfcfkqjX2t1MLeb2WVTdifGyyE/cUFdFCQ/3zFxMQUal3vesHBwb6ybt26+ZYFBQVZcHCwnThxwpKTky08PNzi4uKsVq1advr0aUtKSrLw8HCLjY21yMhIS05OtuzsbMvJybFevXpZZGSk1apVy7Kzs/Pd99nZ2ZacnGy9e/e2nJwcv2UnT540j8djwcHBdurUKb9lZ8+etbi4OAsJCbGkpCS/9b1t9uzZ08LDwy0yMtLOnDlj2dnZlpSU5Ot7r169fGNITk72vSKOi4uzs2fP+tX3Lg8JCbETJ05YUlKS73ZERIT16tXLcnJyLCcnx3r37u3bft75CDTevLfPnj1rvXv39s2Vt62C5i7QPObti1fe+yE5Odk33kBzXpRtFlZxjvl8+0tJ9B2Xr9La18pt2J86dcoyMjJ8lz179hD25fTSsWPHItXv16+f73q7du3yLX/44Yd919966y2TZK+++mq+Mkm2ZMkSMzNbvnx5vrK8lixZYpJsxYoV+ZblbTvQupMnT/Ytz7u+t80JEyb4re8t9/bzzTff9BvD7bffbpLsySef9GvHW/+JJ57wm4dhw4YF3L53zN728/b/3PGee9u77rnzF2j8geaxoLnMez94xxuoXlG2WVjFOebz7S8l0XdcvkprX7vYsC/xo/HHjh2rypUr+y41atQo6U3iIuU9SK8wWrVq5bt++PDhfMu3bNniu96rVy9J0rZt2/KVSVJ6erokqUmTJvnK8gpUzytv24HWzbu9QNuJiIjwK/OWe9fzLvdup2LFipKk2rVr+7XjrV+nTh1J/5kHb71zt++9fu72A4333NsFlQcaf155lweay7xl3vEGqleUbRZWcY75fPtLSfQdl6/yvq+VeNiPHDlSGRkZvsuePXtKepO4SEFBRdsdVq1a5bt+xRVX5Fter1493/WPP/5Y0n8CMG+ZJCUkJEiSNmzYkK8sr0D1vPK2HWjdvNsLtJ2TJ0/6lXnLvet5l3u3c/z4cUnS9u3b/drx1veGpHcevPXO3b73+rnbDzTec28XVB5o/HnlXR5oLvOWeccbqF5RtllYxTnm8+0vJdF3XL7K/b72S95OkPjM/lK98Jk9n9nzmT2f2aP4XPaf2Z+Lo/HduwQ6Gr9///6WmZlpL774oq+sQYMGtmDBAhs9erRf3WeffdYWLFhgN954o0lFOxp/+fLllpmZacuXL893NP7kyZNt7969Nnny5AKPxveun7ef0s9H40+ePDng0fjLly8PeDT+U089FfBo/Lz1zz0av3Xr1r658W77fEfjL1++PODR+N7xX+zR+DfeeKMtWLDAFixYcMGj8c+d85I+Gt875nOPxi/s9ku777h8lca+Vmphn5WVZWvWrLE1a9aYJBs3bpytWbPGdu3aVaIdDcT7D4mwLz+XsjzPvlatWr/oPPvY2NhCn2dfq1atIp1nX5j65xt7Yc45946/KAo6zz5QX8435yWhOMdc2n3H5auk97WLzVCPWZ6vaiuEtLQ0derUKV/5wIEDlZqaesH1MzMzVblyZWVkZCg6Oroomw7I+w16/36goq6dfFxr9hftILPyiG/Q4xv0CjNevkGPb9BD+VSS+9rFZmiRw/6XKu6wl6TnH+qrZ+MW6vkDXfTspJnF0iYAAOXNxWYoP4QDAIDjCHsAABxH2AMA4DjCHgAAxxH2AAA4zomwr1Ontt9fAADwH06EfWRklN9fAADwH06EPQAAKBhhDwCA4wh7AAAcR9gDAOA4wh4AAMcR9gAAOI6wBwDAcYQ9AACOI+wBAHCcE2F/IjhaY9JO60RwdFl3BQCAciekrDtQHLr2/Z1OBkera58+Zd0VAADKHY+ZWWluMDMzU5UrV1ZGRoaio3klDgBAYV1shjrxNj4AACgYYQ8AgOMIewAAHEfYAwDgOMIeAADHEfYAADiOsAcAwHGEPQAAjiPsAQBwHGEPAIDjCHsAABxH2AMA4DjCHgAAxxH2AAA4jrAHAMBxhD0AAI4j7AEAcBxhDwCA4wh7AAAcR9gDAOA4wh4AAMcR9gAAOI6wBwDAcYQ9AACOI+wBAHAcYQ8AgOMIewAAHEfYAwDgOMIeAADHEfYAADiOsAcAwHGEPQAAjiPsAQBwHGEPAIDjCHsAABxH2AMA4DjCHgAAxxH2AAA4jrAHAMBxhD0AAI4j7AEAcBxhDwCA4wh7AAAcR9gDAOA4wh4AAMcR9gAAOI6wBwDAcYQ9AACOI+wBAHAcYQ8AgOMIewAAHEfYAwDgOMIeAADHEfYAADiOsAcAwHGEPQAAjiPsAQBwHGEPAIDjCHsAABxH2AMA4DjCHgAAxxH2AAA4jrAHAMBxhD0AAI4j7AEAcBxhDwCA4wh7AAAcR9gDAOA4wh4AAMcR9gAAOI6wBwDAcYQ9AACOI+wBAHAcYQ8AgOMIewAAHEfYAwDgOMIeAADHEfYAADiOsAcAwHGEPQAAjiPsAQBwHGEPAIDjCHsAABxH2AMA4DjCHgAAxxH2AAA4jrAHAMBxhD0AAI4j7AEAcBxhDwCA4wh7AAAcR9gDAOA4wh4AAMcR9gAAOI6wBwDAcYQ9AACOI+wBAHAcYQ8AgOMIewAAHEfYAwDgOMIeAADHEfYAADiOsAcAwHGEPQAAjiPsAQBwHGEPAIDjCHsAABxH2AMA4DjCHgAAxxH2AAA4jrAHAMBxhD0AAI4j7AEAcBxhDwCA4wh7AAAcR9gDAOA4wh4AAMcR9gAAOI6wBwDAcYQ9AACOI+wBAHAcYQ8AgOMIewAAHEfYAwDgOMIeAADHEfYAADiOsAcAwHEhpb1BM5MkZWZmlvamAQC4pHmz05ulhVXqYZ+VlSVJqlGjRmlvGgAAJ2RlZaly5cqFru+xoj49+IVyc3O1b98+VapUSR6Pp1jazMzMVI0aNbRnzx5FR0cXS5uuYG7Oj/k5P+anYMzN+TE/53ex82NmysrKUmJiooKCCv9JfKm/sg8KCtJVV11VIm1HR0ezUxWAuTk/5uf8mJ+CMTfnx/yc38XMT1Fe0XtxgB4AAI4j7AEAcJwTYR8WFqbRo0crLCysrLtS7jA358f8nB/zUzDm5vyYn/Mr7fkp9QP0AABA6XLilT0AACgYYQ8AgOMIewAAHEfYAwDguEs+7CdMmKDk5GSFh4erdevW+vrrr8u6SyVuzJgx8ng8fpcGDRr4lp86dUoPP/ywrrjiClWsWFF9+/bVgQMH/NrYvXu3evbsqcjISMXGxmr48OHKzs4u7aEUi88//1y9e/dWYmKiPB6P5syZ47fczPTss88qISFBERER6tKli7Zs2eJX58iRI7rrrrsUHR2tKlWq6N5779Xx48f96qxfv17t2rVTeHi4atSooZdffrmkh1YsLjQ/d999d779qVu3bn51XJ2fsWPH6rrrrlOlSpUUGxurPn36aPPmzX51iuvxlJaWpmuvvVZhYWGqW7euUlNTS3p4v1hh5qdjx4759p8HH3zQr46L8zNp0iQ1bdrU96U4KSkp+uSTT3zLy91+Y5ew9957z0JDQ+3vf/+7bdy40e677z6rUqWKHThwoKy7VqJGjx5tjRs3tvT0dN/l0KFDvuUPPvig1ahRwxYtWmSrVq2yG264wdq0aeNbnp2dbU2aNLEuXbrYmjVrbN68eVa9enUbOXJkWQznF5s3b54988wzNmvWLJNks2fP9lv+0ksvWeXKlW3OnDm2bt06u+WWW6xWrVp28uRJX51u3bpZs2bN7KuvvrJly5ZZ3bp1rV+/fr7lGRkZFhcXZ3fddZdt2LDBpk+fbhERETZ58uTSGuZFu9D8DBw40Lp16+a3Px05csSvjqvz07VrV5syZYpt2LDB1q5daz169LCaNWva8ePHfXWK4/G0fft2i4yMtCeeeMI2bdpkb7zxhgUHB9unn35aquMtqsLMT4cOHey+++7z238yMjJ8y12dn48++sjmzp1rP/zwg23evNlGjRplFSpUsA0bNphZ+dtvLumwv/766+3hhx/23c7JybHExEQbO3ZsGfaq5I0ePdqaNWsWcNmxY8esQoUK9sEHH/jKvvvuO5NkK1asMLOf//kHBQXZ/v37fXUmTZpk0dHRdvr06RLte0k7N8xyc3MtPj7eXnnlFV/ZsWPHLCwszKZPn25mZps2bTJJ9s033/jqfPLJJ+bxeGzv3r1mZjZx4kSrWrWq3/yMGDHC6tevX8IjKl4Fhf2tt95a4DqX0/wcPHjQJNnSpUvNrPgeT0899ZQ1btzYb1t33HGHde3ataSHVKzOnR+zn8P+0UcfLXCdy2l+qlatan/961/L5X5zyb6Nf+bMGa1evVpdunTxlQUFBalLly5asWJFGfasdGzZskWJiYmqXbu27rrrLu3evVuStHr1ap09e9ZvXho0aKCaNWv65mXFihW65pprFBcX56vTtWtXZWZmauPGjaU7kBK2Y8cO7d+/328+KleurNatW/vNR5UqVdSqVStfnS5duigoKEgrV6701Wnfvr1CQ0N9dbp27arNmzfr6NGjpTSakpOWlqbY2FjVr19fDz30kA4fPuxbdjnNT0ZGhiSpWrVqkorv8bRixQq/Nrx1LrX/VefOj9f//u//qnr16mrSpIlGjhypEydO+JZdDvOTk5Oj9957Tz/99JNSUlLK5X5T6j+EU1x+/PFH5eTk+E2UJMXFxen7778vo16VjtatWys1NVX169dXenq6nnvuObVr104bNmzQ/v37FRoaqipVqvitExcXp/3790uS9u/fH3DevMtc4h1PoPHmnY/Y2Fi/5SEhIapWrZpfnVq1auVrw7usatWqJdL/0tCtWzf95je/Ua1atbRt2zaNGjVK3bt314oVKxQcHHzZzE9ubq4ee+wx3XjjjWrSpIkkFdvjqaA6mZmZOnnypCIiIkpiSMUq0PxIUv/+/ZWUlKTExEStX79eI0aM0ObNmzVr1ixJbs/Pt99+q5SUFJ06dUoVK1bU7Nmz1ahRI61du7bc7TeXbNhfzrp37+673rRpU7Vu3VpJSUl6//33y+2DAuXXnXfe6bt+zTXXqGnTpqpTp47S0tLUuXPnMuxZ6Xr44Ye1YcMGffHFF2XdlXKpoPm5//77fdevueYaJSQkqHPnztq2bZvq1KlT2t0sVfXr19fatWuVkZGhGTNmaODAgVq6dGlZdyugS/Zt/OrVqys4ODjf0Y0HDhxQfHx8GfWqbFSpUkVXX321tm7dqvj4eJ05c0bHjh3zq5N3XuLj4wPOm3eZS7zjOd9+Eh8fr4MHD/otz87O1pEjRy7LOatdu7aqV6+urVu3Sro85mfo0KH6+OOPtWTJEr+f4C6ux1NBdaKjoy+JJ+gFzU8grVu3liS//cfV+QkNDVXdunXVsmVLjR07Vs2aNdP48ePL5X5zyYZ9aGioWrZsqUWLFvnKcnNztWjRIqWkpJRhz0rf8ePHtW3bNiUkJKhly5aqUKGC37xs3rxZu3fv9s1LSkqKvv32W79/4AsWLFB0dLQaNWpU6v0vSbVq1VJ8fLzffGRmZmrlypV+83Hs2DGtXr3aV2fx4sXKzc31/eNKSUnR559/rrNnz/rqLFiwQPXr178k3qIuiv/7v//T4cOHlZCQIMnt+TEzDR06VLNnz9bixYvzfRRRXI+nlJQUvza8dcr7/6oLzU8ga9eulSS//cfV+TlXbm6uTp8+XT73m6Ifb1h+vPfeexYWFmapqam2adMmu//++61KlSp+Rze6aNiwYZaWlmY7duywL7/80rp06WLVq1e3gwcPmtnPp3zUrFnTFi9ebKtWrbKUlBRLSUnxre895ePmm2+2tWvX2qeffmoxMTGX7Kl3WVlZtmbNGluzZo1JsnHjxtmaNWts165dZvbzqXdVqlSxDz/80NavX2+33nprwFPvWrRoYStXrrQvvvjC6tWr53dq2bFjxywuLs4GDBhgGzZssPfee88iIyPL/allZuefn6ysLHvyySdtxYoVtmPHDlu4cKFde+21Vq9ePTt16pSvDVfn56GHHrLKlStbWlqa36ljJ06c8NUpjseT9xSq4cOH23fffWcTJkwo96eWmV14frZu3WrPP/+8rVq1ynbs2GEffvih1a5d29q3b+9rw9X5efrpp23p0qW2Y8cOW79+vT399NPm8Xhs/vz5Zlb+9ptLOuzNzN544w2rWbOmhYaG2vXXX29fffVVWXepxN1xxx2WkJBgoaGhduWVV9odd9xhW7du9S0/efKkDRkyxKpWrWqRkZH261//2tLT0/3a2Llzp3Xv3t0iIiKsevXqNmzYMDt79mxpD6VYLFmyxCTluwwcONDMfj797o9//KPFxcVZWFiYde7c2TZv3uzXxuHDh61fv35WsWJFi46OtkGDBllWVpZfnXXr1lnbtm0tLCzMrrzySnvppZdKa4i/yPnm58SJE3bzzTdbTEyMVahQwZKSkuy+++7L94TZ1fkJNC+SbMqUKb46xfV4WrJkiTVv3txCQ0Otdu3aftsory40P7t377b27dtbtWrVLCwszOrWrWvDhw/3O8/ezM35ueeeeywpKclCQ0MtJibGOnfu7At6s/K33/ATtwAAOO6S/cweAAAUDmEPAIDjCHsAABxH2AMA4DjCHgAAxxH2AAA4jrAHAMBxhD0AAI4j7IFLSHJysl577bWy7gaASwxhD6DMjRkzRs2bNy/rbgDOIuwBAHAcYQ+UIx07dtTQoUM1dOhQVa5cWdWrV9cf//hHFfQTFuPGjdM111yjqKgo1ahRQ0OGDNHx48clST/99JOio6M1Y8YMv3XmzJmjqKgoZWVlSfr5J2379eunatWqKSoqSq1atdLKlSt99SdNmqQ6deooNDRU9evX17vvvutbtnPnTnk8Ht/PmkrSsWPH5PF4lJaWJklKS0uTx+PRokWL1KpVK0VGRqpNmzbavHmzJCk1NVXPPfec1q1bJ4/HI4/Ho9TU1F86lQDyIOyBcmbq1KkKCQnR119/rfHjx2vcuHH661//GrBuUFCQXn/9dW3cuFFTp07V4sWL9dRTT0mSoqKidOedd2rKlCl+60yZMkW33XabKlWqpOPHj6tDhw7au3evPvroI61bt05PPfWUcnNzJUmzZ8/Wo48+qmHDhmnDhg164IEHNGjQIC1ZsqTI43rmmWf0l7/8RatWrVJISIjuueceSdIdd9yhYcOGqXHjxkpPT1d6erruuOOOIrcP4Dwu6rfyAJSIDh06WMOGDS03N9dXNmLECGvYsKGZmSUlJdmrr75a4PoffPCBXXHFFb7bK1eutODgYNu3b5+ZmR04cMBCQkIsLS3NzMwmT55slSpVssOHDwdsr02bNnbffff5ld1+++3Wo0cPMzPbsWOHSbI1a9b4lh89etQk2ZIlS8zsPz+xu3DhQl+duXPnmiQ7efKkmZmNHj3amjVrdp6ZAfBL8MoeKGduuOEGeTwe3+2UlBRt2bJFOTk5+eouXLhQnTt31pVXXqlKlSppwIABOnz4sE6cOCFJuv7669W4cWNNnTpVkjRt2jQlJSWpffv2kqS1a9eqRYsWqlatWsC+fPfdd7rxxhv9ym688UZ99913RR5X06ZNfdcTEhIkSQcPHixyOwCKjrAHLlE7d+5Ur1691LRpU82cOVOrV6/WhAkTJElnzpzx1Rs8eLDvM/ApU6Zo0KBBvicTERERv6gPQUE//wuxPMcUnD17NmDdChUq+K57t+/9uABAySLsgXIm78FxkvTVV1+pXr16Cg4O9itfvXq1cnNz9Ze//EU33HCDrr76au3bty9fe7/97W+1a9cuvf7669q0aZMGDhzoW9a0aVOtXbtWR44cCdiXhg0b6ssvv/Qr+/LLL9WoUSNJUkxMjCQpPT3dtzzvwXqFFRoaGvCdCwDFg7AHypndu3friSee0ObNmzV9+nS98cYbevTRR/PVq1u3rs6ePas33nhD27dv17vvvqv/+Z//yVevatWq+s1vfqPhw4fr5ptv1lVXXeVb1q9fP8XHx6tPnz768ssvtX37ds2cOVMrVqyQJA0fPlypqamaNGmStmzZonHjxmnWrFl68sknJf38zsANN9ygl156Sd99952WLl2qP/zhD0Uec3Jysnbs2KG1a9fqxx9/1OnTp4vcBoDzKOuDBgD8R4cOHWzIkCH24IMPWnR0tFWtWtVGjRrlO2Dv3AP0xo0bZwkJCRYREWFdu3a1d955xyTZ0aNH/dpdtGiRSbL3338/3zZ37txpffv2tejoaIuMjLRWrVrZypUrfcsnTpxotWvXtgoVKtjVV19t77zzjt/6mzZtspSUFIuIiLDmzZvb/PnzAx6gl7dPa9asMUm2Y8cOMzM7deqU9e3b16pUqWKSbMqUKRc9hwDy85gVcAIvgFLXsWNHNW/evNi/Evfdd9/V448/rn379ik0NLRY2wZQ/oWUdQcAlJwTJ04oPT1dL730kh544AGCHrhM8Zk94LCXX35ZDRo0UHx8vEaOHFnW3QFQRngbHwAAx/HKHgAAxxH2AAA4jrAHAMBxhD0AAI4j7AEAcBxhDwCA4wh7AAAcR9gDAOC4/wcjlNxCJzqgZwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 600x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(6,4))\n",
+    "plt.boxplot(df_hist[\"playcount\"], vert=False)\n",
+    "plt.title(\"Boxplot di playcount\")\n",
+    "plt.xlabel(\"playcount\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f30a5b1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006254,
+     "end_time": "2026-04-11T16:02:49.462835+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:49.456581+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Osservazioni\n",
+    "\n",
+    "- Il boxplot evidenzia la presenza di numerosi outlier\n",
+    "- La distribuzione è fortemente asimmetrica (skewed)\n",
+    "- La mediana è molto vicina al valore minimo\n",
+    "\n",
+    "Gli outlier non rappresentano errori, ma comportamenti reali di utenti molto attivi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa885f74",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006385,
+     "end_time": "2026-04-11T16:02:49.475470+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:49.469085+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Conclusioni\n",
+    "\n",
+    "L’analisi della distribuzione di `playcount` conferma che:\n",
+    "\n",
+    "- la variabile è fortemente sbilanciata verso valori bassi\n",
+    "- la maggior parte delle interazioni presenta un numero ridotto di ascolti\n",
+    "- è presente una lunga coda (long tail) con pochi valori molto elevati\n",
+    "- la distribuzione è altamente asimmetrica\n",
+    "\n",
+    "Questo comportamento è tipico dei sistemi di raccomandazione e delle piattaforme di streaming musicale\n",
+    "\n",
+    "Non si ritiene necessario rimuovere gli outlier, in quanto rappresentano informazioni rilevanti sul comportamento degli utenti"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94ef943f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006348,
+     "end_time": "2026-04-11T16:02:49.488068+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:49.481720+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Preprocessing e creazione del dataset pulito\n",
+    "\n",
+    "In questa sezione vengono applicate le operazioni di preprocessing sul dataset `listening_history`, sulla base delle analisi precedenti.\n",
+    "\n",
+    "L’obiettivo è ottenere un dataset pulito, coerente e pronto per:\n",
+    "- le fasi di integrazione con `music_info`\n",
+    "- la modellazione del database\n",
+    "- eventuali analisi o sistemi di raccomandazione"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41013502",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006154,
+     "end_time": "2026-04-11T16:02:49.500594+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:49.494440+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Scelte di preprocessing\n",
+    "\n",
+    "Sulla base dell’analisi effettuata:\n",
+    "\n",
+    "- non sono presenti valori nulli → nessuna imputazione necessaria\n",
+    "- non sono presenti duplicati → nessuna rimozione necessaria\n",
+    "- i tipi di dato risultano già coerenti → nessuna conversione richiesta\n",
+    "- non sono presenti valori invalidi per `playcount`\n",
+    "\n",
+    "Non vengono effettuate operazioni di pulizia strutturale\n",
+    "\n",
+    "I valori elevati di `playcount` non vengono rimossi, in quanto rappresentano comportamenti reali e informativi\n",
+    "\n",
+    "Il dataset viene mantenuto nella sua forma originale, preservando tutta l’informazione disponibile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "4ab997f4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T16:02:49.515226Z",
+     "iopub.status.busy": "2026-04-11T16:02:49.514817Z",
+     "iopub.status.idle": "2026-04-11T16:03:11.177013Z",
+     "shell.execute_reply": "2026-04-11T16:03:11.176071Z"
+    },
+    "papermill": {
+     "duration": 21.672032,
+     "end_time": "2026-04-11T16:03:11.179034+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:02:49.507002+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset salvato come listening_history_cleaned.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_hist.to_csv(\"listening_history_cleaned.csv\", index=False)\n",
+    "\n",
+    "print(\"Dataset salvato come listening_history_cleaned.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "277c2f9f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006355,
+     "end_time": "2026-04-11T16:03:11.191899+00:00",
+     "exception": false,
+     "start_time": "2026-04-11T16:03:11.185544+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Conclusioni preprocessing\n",
+    "\n",
+    "Le analisi effettuate non hanno evidenziato la necessità di interventi di pulizia o trasformazione dei dati.\n",
+    "\n",
+    "Il dataset `listening_history` viene quindi mantenuto invariato, in quanto già coerente, completo e privo di anomalie rilevanti.\n",
+    "\n",
+    "Il dataframe `df_hist_clean` rappresenta quindi una copia del dataset originale, pronta per le fasi successive del progetto."
+   ]
+  }
+ ],
+ "metadata": {
+  "kaggle": {
+   "accelerator": "none",
+   "dataSources": [
+    {
+     "databundleVersionId": 16606810,
+     "datasetId": 10033503,
+     "sourceId": 15669580,
+     "sourceType": "datasetVersion"
+    },
+    {
+     "databundleVersionId": 5559386,
+     "datasetId": 3166258,
+     "sourceId": 5485048,
+     "sourceType": "datasetVersion"
+    }
+   ],
+   "dockerImageVersionId": 31328,
+   "isGpuEnabled": false,
+   "isInternetEnabled": false,
+   "language": "python",
+   "sourceType": "notebook"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 59.332337,
+   "end_time": "2026-04-11T16:03:11.819955+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "__notebook__.ipynb",
+   "output_path": "__notebook__.ipynb",
+   "parameters": {},
+   "start_time": "2026-04-11T16:02:12.487618+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Questa PR introduce il notebook di analisi e validazione del dataset `listening_history`, utilizzato per rappresentare la cronologia di ascolto degli utenti.

L’obiettivo è stato quello di:
- comprendere la struttura del dataset
- verificare la qualità e la consistenza dei dati
- analizzare la distribuzione delle interazioni
- preparare il dataset per le fasi successive del progetto

---

## Cosa cambia

- aggiunto notebook per analisi esplorativa di `listening_history`
- analizzate dimensioni, colonne e tipi di dato
- calcolate metriche principali (utenti unici, tracce uniche, distribuzione `playcount`)
- verificata qualità dei dati:
  - assenza di valori nulli
  - assenza di duplicati
  - coerenza dei tipi di dato
- analizzata distribuzione di `playcount`:
  - forte asimmetria
  - presenza di long tail
  - identificazione di outlier (non rimossi perché significativi)
- validata la chiave logica (`user_id`, `track_id`)
- documentato che non sono necessarie operazioni di preprocessing

---

## Come testare

1. Aprire il notebook:
` notebooks/data_analysis&pre-processing_ListeningHistory.ipynb`
2. Verificare:
- output delle statistiche descrittive
- assenza di null e duplicati
- grafici di distribuzione del playcount
3. Controllare che il dataset finale venga generato correttamente

---
## Note

- Il dataset listening_history risulta già pulito e coerente.
- Il preprocessing si limita quindi alla validazione dei dati, senza modifiche strutturali.
- Questo dataset è ora pronto per:
- integrazione con music_info
- progettazione delle collezioni MongoDB
- sviluppo di query e analisi successive

Closes #3 