### PR TITLE
Issue 10 admin dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# MongoDB configuration
+MONGO_URI=mongodb://localhost:27017/
+MONGO_DB_NAME=music_archive
+
+# Flask configuration
+# Replace this value with a random secret in your local .env file
+FLASK_SECRET_KEY=change_me_with_a_random_secret_key
+
+# Spotify configuration
+# Optional: used to enable full Spotify metadata retrieval.
+# If left empty, the app falls back to Spotify oEmbed and manual form completion.
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .venv/*
 pyvenv.cfg
 .DS_Store
+.env
+dataset
+mongodb/webapp/__pycache__/
+.python-version

--- a/mongodb/webapp/admin_service.py
+++ b/mongodb/webapp/admin_service.py
@@ -1,0 +1,741 @@
+import base64
+import re
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import requests
+from bson import ObjectId
+from pymongo.database import Database
+from pymongo.errors import DuplicateKeyError
+
+
+ADMIN_CREATED_MARKER = "admin_dashboard"
+
+SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"
+SPOTIFY_TRACK_URL = "https://api.spotify.com/v1/tracks"
+SPOTIFY_OEMBED_URL = "https://open.spotify.com/oembed"
+
+
+def normalize_text(value: Any) -> str:
+    """Restituisce una stringa pulita."""
+    if value is None:
+        return ""
+
+    return str(value).strip()
+
+
+def normalize_optional_number(value: Any, number_type=float):
+    """Converte un valore numerico opzionale oppure restituisce None."""
+    value = normalize_text(value)
+
+    if not value:
+        return None
+
+    try:
+        return number_type(value)
+
+    except ValueError:
+        return None
+
+
+def normalize_tags(raw_tags: str) -> list[str]:
+    """
+    Converte una stringa di tag separati da virgola in lista pulita.
+    """
+    if not raw_tags:
+        return []
+
+    return [
+        tag.strip()
+        for tag in raw_tags.split(",")
+        if tag.strip()
+    ]
+
+
+def normalize_spotify_id(value: Any) -> Optional[str]:
+    """
+    Estrae uno Spotify track ID da:
+    - ID semplice;
+    - URI spotify:track:ID;
+    - URL open.spotify.com/track/ID;
+    - URL album con highlight=spotify:track:ID;
+    - URL con highlight codificato spotify%3Atrack%3AID.
+    """
+    raw_value = normalize_text(value)
+
+    if not raw_value:
+        return None
+
+    patterns = [
+        r"highlight=spotify%3Atrack%3A([A-Za-z0-9]{22})",
+        r"highlight=spotify:track:([A-Za-z0-9]{22})",
+        r"spotify:track:([A-Za-z0-9]{22})",
+        r"open\.spotify\.com/(?:intl-[a-z]{2}/)?track/([A-Za-z0-9]{22})",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, raw_value)
+
+        if match:
+            return match.group(1)
+
+    if re.fullmatch(r"[A-Za-z0-9]{22}", raw_value):
+        return raw_value
+
+    return None
+
+
+def duration_to_ms(minutes: Any, seconds: Any) -> Optional[int]:
+    """Converte minuti e secondi in millisecondi."""
+    minutes_value = normalize_optional_number(minutes, int)
+    seconds_value = normalize_optional_number(seconds, int)
+
+    if minutes_value is None and seconds_value is None:
+        return None
+
+    minutes_value = minutes_value or 0
+    seconds_value = seconds_value or 0
+
+    if minutes_value < 0 or seconds_value < 0:
+        return None
+
+    return ((minutes_value * 60) + seconds_value) * 1000
+
+
+def split_duration_ms(duration_ms: Any) -> tuple[str, str]:
+    """Converte duration_ms in minuti e secondi per il form."""
+    if duration_ms is None:
+        return "", ""
+
+    try:
+        total_seconds = int(float(duration_ms)) // 1000
+
+    except (TypeError, ValueError):
+        return "", ""
+
+    minutes, seconds = divmod(total_seconds, 60)
+
+    return str(minutes), str(seconds)
+
+
+def duration_ms_to_form_values(duration_ms: Any) -> dict:
+    """Restituisce minuti e secondi come dizionario per il frontend."""
+    minutes, seconds = split_duration_ms(duration_ms)
+
+    return {
+        "duration_minutes": minutes,
+        "duration_seconds": seconds,
+    }
+
+
+def build_audio_features(form_data) -> dict:
+    """
+    Costruisce audio_features dai campi opzionali del form.
+    I campi vuoti non vengono inseriti.
+    """
+    numeric_fields = {
+        "danceability": float,
+        "energy": float,
+        "key": int,
+        "loudness": float,
+        "mode": int,
+        "speechiness": float,
+        "acousticness": float,
+        "instrumentalness": float,
+        "liveness": float,
+        "valence": float,
+        "tempo": float,
+    }
+
+    audio_features = {}
+
+    for field_name, number_type in numeric_fields.items():
+        value = normalize_optional_number(
+            form_data.get(field_name),
+            number_type,
+        )
+
+        if value is not None:
+            audio_features[field_name] = value
+
+    return audio_features
+
+
+def get_spotify_access_token(
+    client_id: Optional[str],
+    client_secret: Optional[str],
+) -> Optional[str]:
+    """
+    Recupera un access token Spotify tramite Client Credentials Flow.
+    """
+    if not client_id or not client_secret:
+        return None
+
+    credentials = f"{client_id}:{client_secret}".encode("utf-8")
+
+    encoded_credentials = base64.b64encode(credentials).decode("utf-8")
+
+    try:
+        response = requests.post(
+            SPOTIFY_TOKEN_URL,
+            headers={
+                "Authorization": f"Basic {encoded_credentials}",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            data={
+                "grant_type": "client_credentials",
+            },
+            timeout=8,
+        )
+
+        response.raise_for_status()
+
+        return response.json().get("access_token")
+
+    except requests.RequestException:
+        return None
+
+
+def fetch_spotify_track_metadata(
+    spotify_id: str,
+    client_id: Optional[str],
+    client_secret: Optional[str],
+) -> Optional[dict]:
+    """
+    Recupera metadati completi di una traccia tramite Spotify Web API.
+
+    Restituisce titolo, artista, album, anno, durata e immagine album.
+    """
+    access_token = get_spotify_access_token(
+        client_id,
+        client_secret,
+    )
+
+    if not access_token:
+        return None
+
+    try:
+        response = requests.get(
+            f"{SPOTIFY_TRACK_URL}/{spotify_id}",
+            headers={
+                "Authorization": f"Bearer {access_token}",
+            },
+            timeout=8,
+        )
+
+        response.raise_for_status()
+
+        track_data = response.json()
+
+        artists = track_data.get("artists", [])
+        album = track_data.get("album", {})
+        album_images = album.get("images", [])
+
+        artist_name = (
+            artists[0].get("name")
+            if artists
+            else ""
+        )
+
+        album_name = album.get("name", "")
+        release_date = album.get("release_date", "")
+        year = release_date[:4] if release_date else ""
+
+        album_image_url = (
+            album_images[0].get("url")
+            if album_images
+            else ""
+        )
+
+        return {
+            "spotify_id": spotify_id,
+            "name": track_data.get("name", ""),
+            "artist_name": artist_name,
+            "album_name": album_name,
+            "album_release_date": release_date,
+            "album_image_url": album_image_url,
+            "year": year,
+            "duration_ms": track_data.get("duration_ms"),
+            **duration_ms_to_form_values(track_data.get("duration_ms")),
+            "source": "spotify_web_api",
+        }
+
+    except requests.RequestException:
+        return None
+
+
+def fetch_spotify_oembed_metadata(
+    spotify_id: str,
+) -> Optional[dict]:
+    """
+    Fallback senza credenziali: recupera dati base tramite Spotify oEmbed.
+    """
+    if not spotify_id:
+        return None
+
+    spotify_url = f"https://open.spotify.com/track/{spotify_id}"
+
+    try:
+        response = requests.get(
+            SPOTIFY_OEMBED_URL,
+            params={
+                "url": spotify_url,
+            },
+            timeout=6,
+        )
+
+        response.raise_for_status()
+
+        data = response.json()
+
+        return {
+            "spotify_id": spotify_id,
+            "name": normalize_text(data.get("title")),
+            "artist_name": "",
+            "album_name": "",
+            "album_release_date": "",
+            "album_image_url": data.get("thumbnail_url", ""),
+            "year": "",
+            "duration_ms": None,
+            "duration_minutes": "",
+            "duration_seconds": "",
+            "source": "spotify_oembed",
+        }
+
+    except requests.RequestException:
+        return None
+
+
+def get_spotify_preview(
+    spotify_value: str,
+    client_id: Optional[str],
+    client_secret: Optional[str],
+) -> tuple[bool, dict | str]:
+    """
+    Estrae lo Spotify ID e prova a recuperare i metadati della traccia.
+
+    Usa prima Spotify Web API, poi fallback oEmbed.
+    """
+    spotify_id = normalize_spotify_id(spotify_value)
+
+    if not spotify_id:
+        return False, "Link Spotify non valido."
+
+    metadata = fetch_spotify_track_metadata(
+        spotify_id=spotify_id,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+
+    if metadata:
+        return True, metadata
+
+    metadata = fetch_spotify_oembed_metadata(spotify_id)
+
+    if metadata:
+        return True, metadata
+
+    return (
+        False,
+        "Non è stato possibile recuperare i dati da Spotify. Puoi comunque compilare il form manualmente.",
+    )
+
+
+def get_or_create_artist(
+    db: Database,
+    artist_name: str,
+) -> ObjectId:
+    """
+    Recupera un artista esistente per nome oppure lo crea.
+    """
+    artist_name = normalize_text(artist_name)
+
+    if not artist_name:
+        raise ValueError("Inserisci il nome dell'artista.")
+
+    existing_artist = db.artists.find_one(
+        {
+            "name": {
+                "$regex": f"^{re.escape(artist_name)}$",
+                "$options": "i",
+            }
+        }
+    )
+
+    if existing_artist:
+        return existing_artist["_id"]
+
+    result = db.artists.insert_one(
+        {
+            "name": artist_name,
+            "created_by": ADMIN_CREATED_MARKER,
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+    return result.inserted_id
+
+
+def get_or_create_genre_tag(
+    db: Database,
+    genre: str,
+    tags: list[str],
+) -> ObjectId:
+    """
+    Recupera un documento genres_tags compatibile oppure lo crea.
+    """
+    genre = normalize_text(genre)
+
+    if not genre:
+        raise ValueError("Inserisci il genere della traccia.")
+
+    existing_genre_tag = db.genres_tags.find_one(
+        {
+            "genre": {
+                "$regex": f"^{re.escape(genre)}$",
+                "$options": "i",
+            },
+            "tags": tags,
+        }
+    )
+
+    if existing_genre_tag:
+        return existing_genre_tag["_id"]
+
+    result = db.genres_tags.insert_one(
+        {
+            "genre": genre,
+            "tags": tags,
+            "created_by": ADMIN_CREATED_MARKER,
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+    return result.inserted_id
+
+
+def build_track_document(
+    db: Database,
+    form_data,
+) -> dict:
+    """
+    Crea un documento tracks a partire dai dati del form.
+    """
+    spotify_id = normalize_spotify_id(
+        form_data.get("spotify_url")
+        or form_data.get("spotify_id")
+    )
+
+    title = normalize_text(form_data.get("name"))
+
+    if not title:
+        raise ValueError("Inserisci il titolo della traccia.")
+
+    artist_name = normalize_text(form_data.get("artist_name"))
+    genre = normalize_text(form_data.get("genre"))
+    tags = normalize_tags(form_data.get("tags", ""))
+
+    artist_id = get_or_create_artist(
+        db,
+        artist_name,
+    )
+
+    genre_tag_id = get_or_create_genre_tag(
+        db,
+        genre,
+        tags,
+    )
+
+    duration_ms = duration_to_ms(
+        form_data.get("duration_minutes"),
+        form_data.get("duration_seconds"),
+    )
+
+    year = normalize_optional_number(
+        form_data.get("year"),
+        int,
+    )
+
+    album_name = normalize_text(
+        form_data.get("album_name")
+    )
+
+    album_release_date = normalize_text(
+        form_data.get("album_release_date")
+    )
+
+    album_image_url = normalize_text(
+        form_data.get("album_image_url")
+    )
+
+    audio_features = build_audio_features(form_data)
+
+    now = datetime.now(timezone.utc)
+
+    track_document = {
+        "track_id": f"admin_{ObjectId()}",
+        "name": title,
+        "artist_id": artist_id,
+        "genre_tag_id": genre_tag_id,
+        "audio_features": audio_features,
+        "created_by": ADMIN_CREATED_MARKER,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    if year is not None:
+        track_document["year"] = year
+
+    if duration_ms is not None:
+        track_document["duration_ms"] = duration_ms
+
+    if spotify_id:
+        track_document["spotify_id"] = spotify_id
+
+    if album_name:
+        track_document["album_name"] = album_name
+
+    if album_release_date:
+        track_document["album_release_date"] = album_release_date
+
+    if album_image_url:
+        track_document["album_image_url"] = album_image_url
+
+    return track_document
+
+
+def create_track(
+    db: Database,
+    form_data,
+) -> ObjectId:
+    """Inserisce una nuova traccia."""
+    document = build_track_document(
+        db,
+        form_data,
+    )
+
+    result = db.tracks.insert_one(document)
+
+    return result.inserted_id
+
+
+def update_track(
+    db: Database,
+    track_id: ObjectId,
+    form_data,
+) -> None:
+    """
+    Aggiorna una traccia esistente.
+    """
+    existing_track = db.tracks.find_one(
+        {
+            "_id": track_id,
+        }
+    )
+
+    if not existing_track:
+        raise ValueError("Traccia non trovata.")
+
+    spotify_id = normalize_spotify_id(
+        form_data.get("spotify_url")
+        or form_data.get("spotify_id")
+    )
+
+    name = normalize_text(form_data.get("name"))
+
+    if not name:
+        raise ValueError("Inserisci il titolo della traccia.")
+
+    artist_id = get_or_create_artist(
+        db,
+        form_data.get("artist_name"),
+    )
+
+    genre_tag_id = get_or_create_genre_tag(
+        db,
+        form_data.get("genre"),
+        normalize_tags(form_data.get("tags", "")),
+    )
+
+    duration_ms = duration_to_ms(
+        form_data.get("duration_minutes"),
+        form_data.get("duration_seconds"),
+    )
+
+    year = normalize_optional_number(
+        form_data.get("year"),
+        int,
+    )
+
+    update_fields = {
+        "name": name,
+        "artist_id": artist_id,
+        "genre_tag_id": genre_tag_id,
+        "audio_features": build_audio_features(form_data),
+        "album_name": normalize_text(form_data.get("album_name")),
+        "album_release_date": normalize_text(form_data.get("album_release_date")),
+        "album_image_url": normalize_text(form_data.get("album_image_url")),
+        "updated_at": datetime.now(timezone.utc),
+        "updated_by": ADMIN_CREATED_MARKER,
+    }
+
+    update_fields["year"] = year
+    update_fields["duration_ms"] = duration_ms
+    update_fields["spotify_id"] = spotify_id
+
+    db.tracks.update_one(
+        {
+            "_id": track_id,
+        },
+        {
+            "$set": update_fields,
+        },
+    )
+
+
+def get_track_form_data(
+    db: Database,
+    track_id: ObjectId,
+) -> dict:
+    """
+    Recupera una traccia già arricchita per il form di modifica.
+    """
+    track = db.tracks.find_one(
+        {
+            "_id": track_id,
+        }
+    )
+
+    if not track:
+        raise ValueError("Traccia non trovata.")
+
+    artist = db.artists.find_one(
+        {
+            "_id": track.get("artist_id"),
+        }
+    )
+
+    genre_tag = db.genres_tags.find_one(
+        {
+            "_id": track.get("genre_tag_id"),
+        }
+    )
+
+    minutes, seconds = split_duration_ms(
+        track.get("duration_ms")
+    )
+
+    audio_features = track.get("audio_features") or {}
+
+    return {
+        "_id": track["_id"],
+        "name": track.get("name", ""),
+        "artist_name": artist.get("name", "") if artist else "",
+        "genre": genre_tag.get("genre", "") if genre_tag else "",
+        "tags": ", ".join(genre_tag.get("tags", [])) if genre_tag else "",
+        "year": track.get("year", ""),
+        "duration_minutes": minutes,
+        "duration_seconds": seconds,
+        "spotify_id": track.get("spotify_id", ""),
+        "album_name": track.get("album_name", ""),
+        "album_release_date": track.get("album_release_date", ""),
+        "album_image_url": track.get("album_image_url", ""),
+        "audio_features": audio_features,
+    }
+
+
+def delete_track_if_safe(
+    db: Database,
+    track_id: ObjectId,
+) -> tuple[bool, str]:
+    """
+    Elimina una traccia solo se non esistono ascolti collegati.
+    """
+    linked_history_count = db.listening_history.count_documents(
+        {
+            "track_id": track_id,
+        }
+    )
+
+    if linked_history_count > 0:
+        return (
+            False,
+            (
+                "Non posso eliminare questa traccia perché è già collegata "
+                f"a {linked_history_count} ascolti. "
+                "La cronologia viene preservata per non perdere dati storici."
+            ),
+        )
+
+    result = db.tracks.delete_one(
+        {
+            "_id": track_id,
+        }
+    )
+
+    if result.deleted_count == 0:
+        return False, "Traccia non trovata."
+
+    return True, "Traccia eliminata correttamente."
+
+
+def register_listening_event(
+    db: Database,
+    track_id_value: str,
+    listener_id_value: str,
+) -> tuple[bool, str]:
+    """
+    Collega un listener esistente a una traccia esistente.
+    Gli ObjectId arrivano da input hidden valorizzati tramite autocomplete.
+    """
+    if not ObjectId.is_valid(track_id_value):
+        return False, "Seleziona una traccia dai suggerimenti."
+
+    if not ObjectId.is_valid(listener_id_value):
+        return False, "Seleziona un listener dai suggerimenti."
+
+    track_id = ObjectId(track_id_value)
+    listener_id = ObjectId(listener_id_value)
+
+    track = db.tracks.find_one(
+        {
+            "_id": track_id,
+        }
+    )
+
+    if not track:
+        return False, "Traccia non trovata."
+
+    listener = db.listeners.find_one(
+        {
+            "_id": listener_id,
+        }
+    )
+
+    if not listener:
+        return False, "Listener non trovato."
+
+    existing_history = db.listening_history.find_one(
+        {
+            "track_id": track["_id"],
+            "listener_id": listener["_id"],
+        }
+    )
+
+    if existing_history:
+        return False, "Questo ascolto è già stato registrato."
+
+    try:
+        db.listening_history.insert_one(
+            {
+                "track_id": track["_id"],
+                "listener_id": listener["_id"],
+                "created_by": ADMIN_CREATED_MARKER,
+                "created_at": datetime.now(timezone.utc),
+            }
+        )
+
+    except DuplicateKeyError:
+        return False, "Questo ascolto è già presente."
+
+    return True, "Ascolto registrato correttamente."

--- a/mongodb/webapp/app.py
+++ b/mongodb/webapp/app.py
@@ -10,9 +10,31 @@ from typing import Optional
 import requests
 from PIL import Image, UnidentifiedImageError
 from bson import ObjectId
-from flask import Flask, abort, render_template, request
+from dotenv import load_dotenv
+from flask import (
+    Flask,
+    abort,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
 from pymongo import MongoClient
 from pymongo.errors import PyMongoError
+
+from admin_service import (
+    create_track,
+    delete_track_if_safe,
+    get_spotify_preview,
+    get_track_form_data,
+    register_listening_event,
+    update_track,
+)
+
+
+load_dotenv()
 
 
 MONGO_URI = os.getenv(
@@ -24,6 +46,9 @@ DB_NAME = os.getenv(
     "MONGO_DB_NAME",
     "music_archive",
 )
+
+SPOTIFY_CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
+SPOTIFY_CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
 
 RESULTS_PER_PAGE = 20
 
@@ -45,6 +70,11 @@ DEFAULT_THEME = {
 
 
 app = Flask(__name__)
+
+app.secret_key = os.getenv(
+    "FLASK_SECRET_KEY",
+    "music-archive-dev-secret-key",
+)
 
 mongo_client = MongoClient(
     MONGO_URI,
@@ -119,7 +149,8 @@ def normalize_spotify_id(value) -> Optional[str]:
     Estrae uno Spotify track ID da:
     - ID semplice;
     - URI spotify:track:ID;
-    - URL open.spotify.com/track/ID.
+    - URL open.spotify.com/track/ID;
+    - URL album con highlight=spotify:track:ID.
     """
     if value is None:
         return None
@@ -129,17 +160,18 @@ def normalize_spotify_id(value) -> Optional[str]:
     if not raw_value:
         return None
 
-    if raw_value.startswith("spotify:track:"):
-        raw_value = raw_value.rsplit(":", 1)[-1]
+    patterns = [
+        r"highlight=spotify%3Atrack%3A([A-Za-z0-9]{22})",
+        r"highlight=spotify:track:([A-Za-z0-9]{22})",
+        r"spotify:track:([A-Za-z0-9]{22})",
+        r"open\.spotify\.com/(?:intl-[a-z]{2}/)?track/([A-Za-z0-9]{22})",
+    ]
 
-    if "open.spotify.com/track/" in raw_value:
-        raw_value = raw_value.split(
-            "open.spotify.com/track/",
-            1,
-        )[1]
+    for pattern in patterns:
+        match = re.search(pattern, raw_value)
 
-        raw_value = raw_value.split("?", 1)[0]
-        raw_value = raw_value.split("/", 1)[0]
+        if match:
+            return match.group(1)
 
     if re.fullmatch(r"[A-Za-z0-9]{22}", raw_value):
         return raw_value
@@ -196,6 +228,7 @@ def relative_luminance(
     """
     Calcola la luminanza relativa approssimata del colore.
     """
+
     def linearize(channel: int) -> float:
         value = channel / 255
 
@@ -240,10 +273,7 @@ def extract_dominant_color(
     image_content: bytes,
 ) -> tuple[int, int, int]:
     """
-    Estrae un colore dominante dalla copertina.
-
-    Vengono privilegiati colori frequenti e sufficientemente saturi,
-    evitando per quanto possibile bianco, nero e grigi neutri.
+    Estrae un colore dominante dalla copertina Spotify.
     """
     with Image.open(BytesIO(image_content)) as image:
         image = image.convert("RGB")
@@ -337,9 +367,7 @@ def get_spotify_theme(
 ) -> dict:
     """
     Recupera la copertina tramite Spotify oEmbed ed estrae
-    il colore da applicare alla navbar.
-
-    In caso di errore viene restituito il tema viola predefinito.
+    il colore da applicare alla pagina della traccia.
     """
     if not spotify_id:
         return DEFAULT_THEME.copy()
@@ -873,6 +901,9 @@ def get_artist_tracks(
 
 @app.route("/")
 def index():
+    """
+    Mostra la dashboard principale.
+    """
     error = None
 
     try:
@@ -913,6 +944,9 @@ def index():
 
 @app.route("/tracks")
 def tracks():
+    """
+    Ricerca tracce con filtri combinabili.
+    """
     title_query = request.args.get(
         "q",
         "",
@@ -1006,6 +1040,9 @@ def tracks():
 
 @app.route("/tracks/<track_id>")
 def track_detail(track_id):
+    """
+    Mostra il dettaglio di una traccia.
+    """
     try:
         track_object_id = parse_object_id(track_id)
         track = get_track_detail(track_object_id)
@@ -1038,6 +1075,9 @@ def track_detail(track_id):
 
 @app.route("/artists")
 def artists():
+    """
+    Ricerca artisti.
+    """
     query = request.args.get(
         "q",
         "",
@@ -1091,6 +1131,9 @@ def artists():
 
 @app.route("/artists/<artist_id>")
 def artist_detail(artist_id):
+    """
+    Mostra il dettaglio dell'artista e le tracce associate.
+    """
     artist_object_id = parse_object_id(
         artist_id
     )
@@ -1142,8 +1185,369 @@ def artist_detail(artist_id):
     )
 
 
+@app.route("/admin")
+def admin_dashboard():
+    """
+    Dashboard amministratore con operazioni controllate.
+    """
+    counts = {
+        "tracks": db.tracks.count_documents({}),
+        "artists": db.artists.count_documents({}),
+        "genres_tags": db.genres_tags.count_documents({}),
+        "listeners": db.listeners.count_documents({}),
+        "listening_history": db.listening_history.count_documents({}),
+    }
+
+    recent_tracks = list(
+        db.tracks.find(
+            {},
+            {
+                "_id": 1,
+                "name": 1,
+                "year": 1,
+                "created_at": 1,
+            },
+        )
+        .sort("_id", -1)
+        .limit(10)
+    )
+
+    return render_template(
+        "admin.html",
+        counts=counts,
+        recent_tracks=recent_tracks,
+        page_theme=None,
+    )
+
+
+@app.route("/admin/tracks/new", methods=["GET", "POST"])
+def admin_create_track():
+    """
+    Form amministratore per inserire una nuova traccia.
+    """
+    if request.method == "POST":
+        try:
+            track_id = create_track(
+                db,
+                request.form,
+            )
+
+            flash(
+                "Traccia creata correttamente.",
+                "success",
+            )
+
+            return redirect(
+                url_for(
+                    "track_detail",
+                    track_id=track_id,
+                )
+            )
+
+        except ValueError as error:
+            flash(
+                str(error),
+                "danger",
+            )
+
+        except PyMongoError as error:
+            app.logger.exception(
+                "Errore MongoDB durante la creazione della traccia"
+            )
+
+            flash(
+                f"Errore MongoDB: {error}",
+                "danger",
+            )
+
+    return render_template(
+        "admin_track_form.html",
+        mode="create",
+        track=None,
+        page_theme=None,
+    )
+
+
+@app.route("/admin/tracks/<track_id>/edit", methods=["GET", "POST"])
+def admin_edit_track(track_id):
+    """
+    Form amministratore per modificare una traccia.
+    """
+    track_object_id = parse_object_id(track_id)
+
+    if request.method == "POST":
+        try:
+            update_track(
+                db,
+                track_object_id,
+                request.form,
+            )
+
+            flash(
+                "Traccia aggiornata correttamente.",
+                "success",
+            )
+
+            return redirect(
+                url_for(
+                    "track_detail",
+                    track_id=track_object_id,
+                )
+            )
+
+        except ValueError as error:
+            flash(
+                str(error),
+                "danger",
+            )
+
+        except PyMongoError as error:
+            app.logger.exception(
+                "Errore MongoDB durante la modifica della traccia"
+            )
+
+            flash(
+                f"Errore MongoDB: {error}",
+                "danger",
+            )
+
+    try:
+        track = get_track_form_data(
+            db,
+            track_object_id,
+        )
+
+    except ValueError:
+        abort(404)
+
+    return render_template(
+        "admin_track_form.html",
+        mode="edit",
+        track=track,
+        page_theme=None,
+    )
+
+
+@app.route("/admin/tracks/<track_id>/delete", methods=["POST"])
+def admin_delete_track(track_id):
+    """
+    Elimina una traccia solo se non ha ascolti collegati.
+    """
+    track_object_id = parse_object_id(track_id)
+
+    try:
+        success, message = delete_track_if_safe(
+            db,
+            track_object_id,
+        )
+
+        flash(
+            message,
+            "success" if success else "warning",
+        )
+
+    except PyMongoError as error:
+        app.logger.exception(
+            "Errore MongoDB durante la cancellazione della traccia"
+        )
+
+        flash(
+            f"Errore MongoDB: {error}",
+            "danger",
+        )
+
+    return redirect(
+        url_for("admin_dashboard")
+    )
+
+
+@app.route("/admin/listening/new", methods=["GET", "POST"])
+def admin_create_listening_event():
+    """
+    Registra un ascolto collegando listener esistente e traccia esistente.
+    """
+    if request.method == "POST":
+        try:
+            success, message = register_listening_event(
+                db=db,
+                track_id_value=request.form.get("track_id", ""),
+                listener_id_value=request.form.get("listener_id", ""),
+            )
+
+            flash(
+                message,
+                "success" if success else "warning",
+            )
+
+            if success:
+                return redirect(
+                    url_for("admin_dashboard")
+                )
+
+        except PyMongoError as error:
+            app.logger.exception(
+                "Errore MongoDB durante la registrazione ascolto"
+            )
+
+            flash(
+                f"Errore MongoDB: {error}",
+                "danger",
+            )
+
+    return render_template(
+        "admin_listening.html",
+        page_theme=None,
+    )
+
+
+@app.route("/admin/api/spotify/preview")
+def admin_spotify_preview():
+    """
+    Restituisce metadati Spotify per auto-compilare il form traccia.
+    """
+    spotify_url = request.args.get(
+        "url",
+        "",
+    ).strip()
+
+    success, payload = get_spotify_preview(
+        spotify_value=spotify_url,
+        client_id=SPOTIFY_CLIENT_ID,
+        client_secret=SPOTIFY_CLIENT_SECRET,
+    )
+
+    if not success:
+        return jsonify(
+            {
+                "success": False,
+                "message": payload,
+            }
+        ), 400
+
+    return jsonify(
+        {
+            "success": True,
+            "track": payload,
+        }
+    )
+
+
+@app.route("/admin/api/tracks/search")
+def admin_search_tracks_api():
+    """
+    Ricerca tracce per autocomplete nella dashboard admin.
+    """
+    query = request.args.get(
+        "q",
+        "",
+    ).strip()
+
+    if len(query) < 2:
+        return jsonify([])
+
+    pipeline = [
+        {
+            "$match": {
+                "name": {
+                    "$regex": re.escape(query),
+                    "$options": "i",
+                }
+            }
+        },
+        {
+            "$lookup": {
+                "from": "artists",
+                "localField": "artist_id",
+                "foreignField": "_id",
+                "as": "artist",
+            }
+        },
+        {
+            "$unwind": {
+                "path": "$artist",
+                "preserveNullAndEmptyArrays": True,
+            }
+        },
+        {
+            "$limit": 8,
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$toString": "$_id",
+                },
+                "name": 1,
+                "artist_name": {
+                    "$ifNull": [
+                        "$artist.name",
+                        "Artista sconosciuto",
+                    ]
+                },
+                "year": 1,
+            }
+        },
+    ]
+
+    results = list(
+        db.tracks.aggregate(
+            pipeline,
+            allowDiskUse=True,
+        )
+    )
+
+    return jsonify(results)
+
+
+@app.route("/admin/api/listeners/search")
+def admin_search_listeners_api():
+    """
+    Ricerca listener per autocomplete nella dashboard admin.
+    """
+    query = request.args.get(
+        "q",
+        "",
+    ).strip()
+
+    if len(query) < 2:
+        return jsonify([])
+
+    search_filter = {
+        "original_user_id": {
+            "$regex": re.escape(query),
+            "$options": "i",
+        }
+    }
+
+    listeners = list(
+        db.listeners.find(
+            search_filter,
+            {
+                "_id": 1,
+                "original_user_id": 1,
+            },
+        )
+        .limit(8)
+    )
+
+    results = [
+        {
+            "_id": str(listener["_id"]),
+            "original_user_id": listener.get(
+                "original_user_id",
+                "",
+            ),
+        }
+        for listener in listeners
+    ]
+
+    return jsonify(results)
+
+
 @app.template_filter("format_number")
 def format_number(value):
+    """
+    Formatta i numeri con separatore delle migliaia.
+    """
     try:
         return f"{int(value):,}".replace(
             ",",
@@ -1156,6 +1560,9 @@ def format_number(value):
 
 @app.template_filter("format_datetime")
 def format_datetime(value):
+    """
+    Rende leggibile una data ISO.
+    """
     if not value:
         return ""
 

--- a/mongodb/webapp/requirements.txt
+++ b/mongodb/webapp/requirements.txt
@@ -2,3 +2,4 @@ Flask>=3.0,<4.0
 pymongo>=4.6,<5.0
 requests>=2.31,<3.0
 Pillow>=10.0,<12.0
+python-dotenv>=1.0,<2.0

--- a/mongodb/webapp/static/css/style.css
+++ b/mongodb/webapp/static/css/style.css
@@ -336,6 +336,34 @@ code {
     background: var(--surface);
 }
 
+.admin-form {
+    max-width: 1100px;
+}
+
+.admin-form .form-label {
+    font-weight: 600;
+}
+
+.admin-form input,
+.admin-form select,
+.admin-form textarea {
+    border-radius: 0.75rem;
+}
+
+.alert {
+    border-radius: 0.9rem;
+}
+
+.btn-outline-danger {
+    border-color: #dc3545;
+    color: #dc3545;
+}
+
+.btn-outline-danger:hover {
+    color: #ffffff;
+    background: #dc3545;
+}
+
 @media (max-width: 991.98px) {
     .spotify-card {
         position: static;
@@ -362,4 +390,44 @@ code {
     .spotify-card-header {
         align-items: flex-start;
     }
+}
+
+.autocomplete-field {
+    position: relative;
+}
+
+.autocomplete-suggestions {
+    position: absolute;
+    z-index: 20;
+    width: 100%;
+    margin-top: 0.35rem;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: 0.85rem;
+    background: var(--surface);
+    box-shadow: 0 1rem 2rem rgba(37, 38, 58, 0.12);
+}
+
+.autocomplete-item {
+    display: block;
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border: 0;
+    border-bottom: 1px solid var(--border);
+    color: var(--text);
+    background: transparent;
+    text-align: left;
+}
+
+.autocomplete-item:last-child {
+    border-bottom: 0;
+}
+
+.autocomplete-item:hover,
+.autocomplete-item:focus {
+    background: var(--background);
+}
+
+.spotify-preview-status {
+    border-radius: 0.85rem;
 }

--- a/mongodb/webapp/static/js/admin.js
+++ b/mongodb/webapp/static/js/admin.js
@@ -1,0 +1,262 @@
+function debounce(callback, delay = 300) {
+    let timeoutId = null;
+
+    return function (...args) {
+        clearTimeout(timeoutId);
+
+        timeoutId = setTimeout(
+            () => callback.apply(this, args),
+            delay
+        );
+    };
+}
+
+function showStatus(element, message, type = "info") {
+    if (!element) {
+        return;
+    }
+
+    element.className = `spotify-preview-status mt-3 alert alert-${type}`;
+    element.textContent = message;
+    element.classList.remove("d-none");
+}
+
+function setInputValue(id, value) {
+    const element = document.getElementById(id);
+
+    if (!element || value === undefined || value === null) {
+        return;
+    }
+
+    element.value = value;
+}
+
+async function fetchSpotifyPreview() {
+    const spotifyInput = document.getElementById("spotify_url");
+    const statusBox = document.getElementById("spotify_preview_status");
+
+    if (!spotifyInput || !statusBox) {
+        return;
+    }
+
+    const spotifyUrl = spotifyInput.value.trim();
+
+    if (spotifyUrl.length === 0) {
+        showStatus(
+            statusBox,
+            "Incolla prima un link Spotify.",
+            "warning"
+        );
+
+        return;
+    }
+
+    showStatus(
+        statusBox,
+        "Recupero dati da Spotify...",
+        "info"
+    );
+
+    try {
+        const response = await fetch(
+            `/admin/api/spotify/preview?url=${encodeURIComponent(spotifyUrl)}`
+        );
+
+        const data = await response.json();
+
+        if (!response.ok || !data.success) {
+            showStatus(
+                statusBox,
+                data.message || "Impossibile recuperare i dati da Spotify.",
+                "warning"
+            );
+
+            return;
+        }
+
+        const track = data.track;
+
+        setInputValue("spotify_url", track.spotify_id);
+        setInputValue("name", track.name);
+        setInputValue("artist_name", track.artist_name);
+        setInputValue("album_name", track.album_name);
+        setInputValue("album_release_date", track.album_release_date);
+        setInputValue("album_image_url", track.album_image_url);
+        setInputValue("year", track.year);
+        setInputValue("duration_minutes", track.duration_minutes);
+        setInputValue("duration_seconds", track.duration_seconds);
+
+        const sourceLabel = track.source === "spotify_web_api"
+            ? "Spotify Web API"
+            : "Spotify oEmbed";
+
+        showStatus(
+            statusBox,
+            `Dati recuperati da ${sourceLabel}. Puoi modificarli prima di salvare.`,
+            "success"
+        );
+
+    } catch (error) {
+        showStatus(
+            statusBox,
+            "Errore durante il recupero dei dati Spotify.",
+            "danger"
+        );
+    }
+}
+
+function clearSuggestions(container) {
+    if (!container) {
+        return;
+    }
+
+    container.innerHTML = "";
+    container.classList.add("d-none");
+}
+
+function renderSuggestions(container, items, onSelect) {
+    clearSuggestions(container);
+
+    if (!items || items.length === 0) {
+        return;
+    }
+
+    items.forEach((item) => {
+        const button = document.createElement("button");
+
+        button.type = "button";
+        button.className = "autocomplete-item";
+
+        button.textContent = item.label;
+
+        button.addEventListener("click", () => {
+            onSelect(item);
+            clearSuggestions(container);
+        });
+
+        container.appendChild(button);
+    });
+
+    container.classList.remove("d-none");
+}
+
+async function searchTracks(query) {
+    const response = await fetch(
+        `/admin/api/tracks/search?q=${encodeURIComponent(query)}`
+    );
+
+    const tracks = await response.json();
+
+    return tracks.map((track) => {
+        const year = track.year ? ` (${track.year})` : "";
+
+        return {
+            id: track._id,
+            label: `${track.name} — ${track.artist_name}${year}`,
+        };
+    });
+}
+
+async function searchListeners(query) {
+    const response = await fetch(
+        `/admin/api/listeners/search?q=${encodeURIComponent(query)}`
+    );
+
+    const listeners = await response.json();
+
+    return listeners.map((listener) => {
+        return {
+            id: listener._id,
+            label: listener.original_user_id,
+        };
+    });
+}
+
+function setupTrackAutocomplete() {
+    const searchInput = document.getElementById("track_search");
+    const hiddenInput = document.getElementById("track_id");
+    const suggestionsBox = document.getElementById("track_suggestions");
+
+    if (!searchInput || !hiddenInput || !suggestionsBox) {
+        return;
+    }
+
+    searchInput.addEventListener("input", debounce(async () => {
+        hiddenInput.value = "";
+
+        const query = searchInput.value.trim();
+
+        if (query.length < 2) {
+            clearSuggestions(suggestionsBox);
+            return;
+        }
+
+        const results = await searchTracks(query);
+
+        renderSuggestions(
+            suggestionsBox,
+            results,
+            (selectedTrack) => {
+                searchInput.value = selectedTrack.label;
+                hiddenInput.value = selectedTrack.id;
+            }
+        );
+    }));
+}
+
+function setupListenerAutocomplete() {
+    const searchInput = document.getElementById("listener_search");
+    const hiddenInput = document.getElementById("listener_id");
+    const suggestionsBox = document.getElementById("listener_suggestions");
+
+    if (!searchInput || !hiddenInput || !suggestionsBox) {
+        return;
+    }
+
+    searchInput.addEventListener("input", debounce(async () => {
+        hiddenInput.value = "";
+
+        const query = searchInput.value.trim();
+
+        if (query.length < 2) {
+            clearSuggestions(suggestionsBox);
+            return;
+        }
+
+        const results = await searchListeners(query);
+
+        renderSuggestions(
+            suggestionsBox,
+            results,
+            (selectedListener) => {
+                searchInput.value = selectedListener.label;
+                hiddenInput.value = selectedListener.id;
+            }
+        );
+    }));
+}
+
+function setupSpotifyPreview() {
+    const spotifyButton = document.getElementById("spotify_preview_button");
+    const spotifyInput = document.getElementById("spotify_url");
+
+    if (!spotifyButton || !spotifyInput) {
+        return;
+    }
+
+    spotifyButton.addEventListener(
+        "click",
+        fetchSpotifyPreview
+    );
+
+    spotifyInput.addEventListener(
+        "change",
+        fetchSpotifyPreview
+    );
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    setupSpotifyPreview();
+    setupTrackAutocomplete();
+    setupListenerAutocomplete();
+});

--- a/mongodb/webapp/templates/admin.html
+++ b/mongodb/webapp/templates/admin.html
@@ -1,0 +1,154 @@
+{% extends "base.html" %}
+
+{% block title %}
+Admin | Music Archive
+{% endblock %}
+
+{% block content %}
+<section class="page-header mb-4">
+    <h1 class="fw-bold">Dashboard amministratore</h1>
+
+    <p class="text-secondary mb-0">
+        Gestisci operazioni controllate su tracce e ascolti.
+    </p>
+</section>
+
+<div class="row g-3 mb-4">
+    <div class="col-12 col-md-6 col-xl">
+        <div class="stat-card">
+            <span class="stat-label">Tracce</span>
+            <strong class="stat-value">
+                {{ counts.tracks | format_number }}
+            </strong>
+        </div>
+    </div>
+
+    <div class="col-12 col-md-6 col-xl">
+        <div class="stat-card">
+            <span class="stat-label">Artisti</span>
+            <strong class="stat-value">
+                {{ counts.artists | format_number }}
+            </strong>
+        </div>
+    </div>
+
+    <div class="col-12 col-md-6 col-xl">
+        <div class="stat-card">
+            <span class="stat-label">Generi/tag</span>
+            <strong class="stat-value">
+                {{ counts.genres_tags | format_number }}
+            </strong>
+        </div>
+    </div>
+
+    <div class="col-12 col-md-6 col-xl">
+        <div class="stat-card">
+            <span class="stat-label">Listener</span>
+            <strong class="stat-value">
+                {{ counts.listeners | format_number }}
+            </strong>
+        </div>
+    </div>
+
+    <div class="col-12 col-md-6 col-xl">
+        <div class="stat-card">
+            <span class="stat-label">Ascolti</span>
+            <strong class="stat-value">
+                {{ counts.listening_history | format_number }}
+            </strong>
+        </div>
+    </div>
+</div>
+
+<section class="dashboard-card mb-4">
+    <h2 class="section-title">Azioni rapide</h2>
+
+    <div class="d-flex flex-wrap gap-2">
+        <a
+            class="btn btn-primary"
+            href="{{ url_for('admin_create_track') }}"
+        >
+            Nuova traccia
+        </a>
+
+        <a
+            class="btn btn-outline-primary"
+            href="{{ url_for('admin_create_listening_event') }}"
+        >
+            Registra ascolto
+        </a>
+
+        <a
+            class="btn btn-outline-secondary"
+            href="{{ url_for('tracks') }}"
+        >
+            Cerca tracce
+        </a>
+    </div>
+</section>
+
+<section class="dashboard-card">
+    <h2 class="section-title">Tracce recenti</h2>
+
+    <div class="table-responsive">
+        <table class="table align-middle">
+            <thead>
+            <tr>
+                <th>Titolo</th>
+                <th>Anno</th>
+                <th class="text-end">Azioni</th>
+            </tr>
+            </thead>
+
+            <tbody>
+            {% for track in recent_tracks %}
+                <tr>
+                    <td>
+                        <a
+                            class="item-link fw-semibold"
+                            href="{{ url_for('track_detail', track_id=track._id) }}"
+                        >
+                            {{ track.name }}
+                        </a>
+                    </td>
+
+                    <td>
+                        {{ track.year or "—" }}
+                    </td>
+
+                    <td class="text-end">
+                        <div class="d-inline-flex gap-2">
+                            <a
+                                class="btn btn-outline-primary btn-sm"
+                                href="{{ url_for('admin_edit_track', track_id=track._id) }}"
+                            >
+                                Modifica
+                            </a>
+
+                            <form
+                                method="post"
+                                action="{{ url_for('admin_delete_track', track_id=track._id) }}"
+                                onsubmit="return confirm('Vuoi davvero eliminare questa traccia? L’operazione sarà bloccata se esistono ascolti collegati.');"
+                            >
+                                <button
+                                    type="submit"
+                                    class="btn btn-outline-danger btn-sm"
+                                >
+                                    Elimina
+                                </button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="3">
+                        Nessuna traccia disponibile.
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+{% endblock %}

--- a/mongodb/webapp/templates/admin_listening.html
+++ b/mongodb/webapp/templates/admin_listening.html
@@ -1,0 +1,92 @@
+{% extends "base.html" %}
+
+{% block title %}
+Registra ascolto | Music Archive
+{% endblock %}
+
+{% block content %}
+<section class="page-header mb-4">
+    <h1 class="fw-bold">Registra ascolto</h1>
+
+    <p class="text-secondary mb-0">
+        Seleziona una traccia e un listener esistente per aggiungere un nuovo ascolto alla cronologia.
+    </p>
+</section>
+
+<form method="post" class="dashboard-card admin-form">
+    <div class="mb-4 autocomplete-field">
+        <label class="form-label" for="track_search">
+            Traccia
+        </label>
+
+        <input
+            class="form-control"
+            id="track_search"
+            autocomplete="off"
+            placeholder="Cerca una traccia per titolo"
+            required
+        >
+
+        <input
+            type="hidden"
+            id="track_id"
+            name="track_id"
+        >
+
+        <div
+            id="track_suggestions"
+            class="autocomplete-suggestions d-none"
+        ></div>
+
+        <small class="text-secondary">
+            Scrivi almeno due caratteri e seleziona una traccia dai risultati.
+        </small>
+    </div>
+
+    <div class="mb-4 autocomplete-field">
+        <label class="form-label" for="listener_search">
+            Listener
+        </label>
+
+        <input
+            class="form-control"
+            id="listener_search"
+            autocomplete="off"
+            placeholder="Cerca un listener"
+            required
+        >
+
+        <input
+            type="hidden"
+            id="listener_id"
+            name="listener_id"
+        >
+
+        <div
+            id="listener_suggestions"
+            class="autocomplete-suggestions d-none"
+        ></div>
+
+        <small class="text-secondary">
+            Seleziona un listener esistente dalla lista dei suggerimenti.
+        </small>
+    </div>
+
+    <div class="d-flex flex-wrap gap-2">
+        <button class="btn btn-primary" type="submit">
+            Registra ascolto
+        </button>
+
+        <a
+            class="btn btn-outline-secondary"
+            href="{{ url_for('admin_dashboard') }}"
+        >
+            Annulla
+        </a>
+    </div>
+</form>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/admin.js') }}"></script>
+{% endblock %}

--- a/mongodb/webapp/templates/admin_track_form.html
+++ b/mongodb/webapp/templates/admin_track_form.html
@@ -1,0 +1,271 @@
+{% extends "base.html" %}
+
+{% block title %}
+{% if mode == "edit" %}Modifica traccia{% else %}Nuova traccia{% endif %} | Music Archive
+{% endblock %}
+
+{% block content %}
+<section class="page-header mb-4">
+    <h1 class="fw-bold">
+        {% if mode == "edit" %}
+            Modifica traccia
+        {% else %}
+            Nuova traccia
+        {% endif %}
+    </h1>
+
+    <p class="text-secondary mb-0">
+        Gestisci le informazioni della traccia e, se disponibile, usa Spotify per compilare automaticamente i dati principali.
+    </p>
+</section>
+
+<form method="post" class="dashboard-card admin-form">
+    <h2 class="section-title">Spotify</h2>
+
+    <div class="row g-3 align-items-end">
+        <div class="col-12 col-lg-9">
+            <label class="form-label" for="spotify_url">
+                Link Spotify
+            </label>
+
+            <input
+                class="form-control"
+                id="spotify_url"
+                name="spotify_url"
+                value="{{ track.spotify_id if track else '' }}"
+                placeholder="Incolla qui il link della traccia Spotify"
+            >
+
+            <small class="text-secondary">
+                Puoi incollare un link traccia Spotify o un link album che contiene una traccia evidenziata.
+            </small>
+        </div>
+
+        <div class="col-12 col-lg-3">
+            <button
+                class="btn btn-outline-primary w-100"
+                type="button"
+                id="spotify_preview_button"
+            >
+                Compila da Spotify
+            </button>
+        </div>
+    </div>
+
+    <div
+        id="spotify_preview_status"
+        class="spotify-preview-status mt-3 d-none"
+    ></div>
+
+    <hr class="my-4">
+
+    <h2 class="section-title">Informazioni principali</h2>
+
+    <div class="row g-3">
+        <div class="col-12 col-lg-6">
+            <label class="form-label" for="name">
+                Titolo
+            </label>
+
+            <input
+                class="form-control"
+                id="name"
+                name="name"
+                value="{{ track.name if track else '' }}"
+                placeholder="Titolo della traccia"
+                required
+            >
+        </div>
+
+        <div class="col-12 col-lg-6">
+            <label class="form-label" for="artist_name">
+                Artista
+            </label>
+
+            <input
+                class="form-control"
+                id="artist_name"
+                name="artist_name"
+                value="{{ track.artist_name if track else '' }}"
+                placeholder="Nome dell'artista"
+                required
+            >
+        </div>
+
+        <div class="col-12 col-lg-6">
+            <label class="form-label" for="album_name">
+                Album
+            </label>
+
+            <input
+                class="form-control"
+                id="album_name"
+                name="album_name"
+                value="{{ track.album_name if track else '' }}"
+                placeholder="Nome dell'album"
+            >
+        </div>
+
+        <div class="col-12 col-lg-6">
+            <label class="form-label" for="album_release_date">
+                Data di uscita album
+            </label>
+
+            <input
+                class="form-control"
+                id="album_release_date"
+                name="album_release_date"
+                value="{{ track.album_release_date if track else '' }}"
+                placeholder="Es. 2015-06-12"
+            >
+        </div>
+
+        <input
+            type="hidden"
+            id="album_image_url"
+            name="album_image_url"
+            value="{{ track.album_image_url if track else '' }}"
+        >
+
+        <div class="col-12 col-md-6">
+            <label class="form-label" for="genre">
+                Genere
+            </label>
+
+            <input
+                class="form-control"
+                id="genre"
+                name="genre"
+                value="{{ track.genre if track else '' }}"
+                placeholder="Es. Rock, Pop, Electronic"
+                required
+            >
+        </div>
+
+        <div class="col-12 col-md-6">
+            <label class="form-label" for="tags">
+                Tag
+            </label>
+
+            <input
+                class="form-control"
+                id="tags"
+                name="tags"
+                value="{{ track.tags if track else '' }}"
+                placeholder="Es. rock, 80s, classic"
+            >
+        </div>
+
+        <div class="col-12 col-md-4">
+            <label class="form-label" for="year">
+                Anno
+            </label>
+
+            <input
+                class="form-control"
+                id="year"
+                name="year"
+                type="number"
+                min="1900"
+                max="2100"
+                value="{{ track.year if track else '' }}"
+                placeholder="Es. 2015"
+            >
+        </div>
+
+        <div class="col-6 col-md-4">
+            <label class="form-label" for="duration_minutes">
+                Minuti
+            </label>
+
+            <input
+                class="form-control"
+                id="duration_minutes"
+                name="duration_minutes"
+                type="number"
+                min="0"
+                value="{{ track.duration_minutes if track else '' }}"
+                placeholder="3"
+            >
+        </div>
+
+        <div class="col-6 col-md-4">
+            <label class="form-label" for="duration_seconds">
+                Secondi
+            </label>
+
+            <input
+                class="form-control"
+                id="duration_seconds"
+                name="duration_seconds"
+                type="number"
+                min="0"
+                max="59"
+                value="{{ track.duration_seconds if track else '' }}"
+                placeholder="42"
+            >
+        </div>
+    </div>
+
+    <hr class="my-4">
+
+    <h2 class="section-title">Audio features opzionali</h2>
+
+    <p class="text-secondary">
+        Le audio features possono essere inserite manualmente se disponibili. Se non le conosci, puoi lasciarle vuote.
+    </p>
+
+    {% set audio = track.audio_features if track else {} %}
+
+    <div class="row g-3">
+        {% for field in [
+            'danceability',
+            'energy',
+            'key',
+            'loudness',
+            'mode',
+            'speechiness',
+            'acousticness',
+            'instrumentalness',
+            'liveness',
+            'valence',
+            'tempo'
+        ] %}
+            <div class="col-12 col-md-4">
+                <label class="form-label" for="{{ field }}">
+                    {{ field.replace('_', ' ') | title }}
+                </label>
+
+                <input
+                    class="form-control"
+                    id="{{ field }}"
+                    name="{{ field }}"
+                    value="{{ audio.get(field, '') }}"
+                    placeholder="Opzionale"
+                >
+            </div>
+        {% endfor %}
+    </div>
+
+    <div class="d-flex flex-wrap gap-2 mt-4">
+        <button class="btn btn-primary" type="submit">
+            {% if mode == "edit" %}
+                Salva modifiche
+            {% else %}
+                Crea traccia
+            {% endif %}
+        </button>
+
+        <a
+            class="btn btn-outline-secondary"
+            href="{{ url_for('admin_dashboard') }}"
+        >
+            Annulla
+        </a>
+    </div>
+</form>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/admin.js') }}"></script>
+{% endblock %}

--- a/mongodb/webapp/templates/base.html
+++ b/mongodb/webapp/templates/base.html
@@ -91,12 +91,41 @@
                         Artisti
                     </a>
                 </li>
+
+                <li class="nav-item">
+                    <a
+                        class="nav-link"
+                        href="{{ url_for('admin_dashboard') }}"
+                    >
+                        Admin
+                    </a>
+                </li>
             </ul>
         </div>
     </div>
 </nav>
 
 <main class="container py-4">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div
+                    class="alert alert-{{ category }} alert-dismissible fade show"
+                    role="alert"
+                >
+                    {{ message }}
+
+                    <button
+                        type="button"
+                        class="btn-close"
+                        data-bs-dismiss="alert"
+                        aria-label="Chiudi"
+                    ></button>
+                </div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+
     {% if error %}
         <div
             class="alert alert-danger"
@@ -117,7 +146,7 @@
         </p>
 
         <small>
-            Dashboard Flask collegata a MongoDB in sola lettura.
+            Dashboard Flask collegata a MongoDB.
         </small>
     </div>
 </footer>
@@ -125,5 +154,7 @@
 <script
     src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
 ></script>
+
+{% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Questa PR introduce una dashboard amministratore per gestire operazioni CRUD controllate sul database MongoDB `music_archive`.

L’obiettivo è stato quello di:

* aggiungere una sezione amministrativa alla web app Flask;
* permettere la creazione, modifica ed eliminazione controllata delle tracce;
* registrare nuovi ascolti collegando listener esistenti a tracce esistenti;
* preservare l’integrità dei riferimenti tra le collection;
* migliorare l’usabilità dell’interfaccia evitando l’inserimento manuale di identificativi tecnici;
* supportare una compilazione assistita dei dati tramite link Spotify.

---

## Cosa cambia

* Aggiunta la sezione amministratore accessibile dalla navbar.
* Aggiunta una dashboard admin con riepilogo dei dati principali del database.
* Aggiunta la possibilità di creare nuove tracce tramite form.
* Aggiunta la possibilità di modificare tracce esistenti.
* Aggiunta la possibilità di eliminare una traccia solo se non ha ascolti collegati.
* Bloccata la cancellazione di tracce già presenti nella cronologia degli ascolti.
* Aggiunta la creazione o il riutilizzo automatico di artista e genere/tag durante la gestione delle tracce.
* Aggiunti campi manuali per:

  * titolo;
  * artista;
  * album;
  * genere;
  * tag;
  * anno;
  * durata;
  * audio features opzionali.
* Aggiunto il supporto all’inserimento assistito tramite link Spotify.
* Implementata l’estrazione dello Spotify track ID da URL, URI e link album con traccia evidenziata.
* Aggiunto il recupero dei metadati tramite Spotify Web API quando sono disponibili credenziali valide.
* Aggiunto fallback tramite Spotify oEmbed quando la Web API non è disponibile.
* Aggiunta la possibilità di completare manualmente i campi non recuperati automaticamente.
* Aggiunta una pagina per registrare un nuovo ascolto.
* Aggiunta la selezione di tracce e listener tramite ricerca con suggerimenti.
* Evitato l’inserimento manuale degli ObjectId nell’interfaccia.
* Aggiunto il controllo per impedire ascolti duplicati.
* Separata la logica amministrativa in un modulo dedicato.
* Aggiunto JavaScript dedicato per autocompletamento e compilazione assistita da Spotify.
* Aggiornati testi, placeholder e messaggi dell’interfaccia.
* Aggiunto un file `.env.example` per documentare le variabili d’ambiente configurabili.
* Aggiornato `.gitignore` per escludere file locali e credenziali sensibili.
* Aggiornate le dipendenze della web app.

---

## Come testare

1. Assicurarsi che MongoDB sia avviato e che il database `music_archive` sia già popolato.

2. Installare le dipendenze della web app:

   ```bash
   pip install -r mongodb/webapp/requirements.txt
   ```

3. Creare un file `.env` locale partendo da `.env.example`.

   Esempio:

   ```bash
   cp .env.example .env
   ```

4. Configurare almeno le variabili principali:

   ```env
   MONGO_URI=mongodb://localhost:27017/
   MONGO_DB_NAME=music_archive
   FLASK_SECRET_KEY=una_stringa_segreta_locale
   ```

5. Le credenziali Spotify sono opzionali. Se disponibili, aggiungere:

   ```env
   SPOTIFY_CLIENT_ID=...
   SPOTIFY_CLIENT_SECRET=...
   ```

6. Avviare la web app:

   ```bash
   python mongodb/webapp/app.py
   ```

7. Aprire nel browser:

   ```text
   http://127.0.0.1:5000/admin
   ```

8. Verificare che la dashboard amministratore mostri il riepilogo delle collection principali.

9. Testare la creazione di una nuova traccia:

   * compilando manualmente i campi;
   * oppure incollando un link Spotify e usando la compilazione assistita.

10. Verificare che, quando la Spotify Web API è disponibile, vengano recuperati i metadati principali della traccia.

11. Verificare che, quando la Spotify Web API non è disponibile, venga usato il fallback tramite Spotify oEmbed oppure sia possibile completare manualmente il form.

12. Modificare una traccia esistente e verificare che i dati vengano aggiornati correttamente.

13. Eliminare una traccia appena creata senza ascolti collegati e verificare che la cancellazione venga completata.

14. Registrare un ascolto selezionando una traccia e un listener tramite suggerimenti.

15. Provare a registrare lo stesso ascolto una seconda volta e verificare che il duplicato venga bloccato.

16. Provare a eliminare una traccia con ascolti collegati e verificare che la cancellazione venga bloccata.

17. Eseguire la validazione del database:

```bash
python mongodb/scripts/validate_database.py
```

18. Verificare che la validazione continui a restituire esito corretto.

---

## Note

* La dashboard amministratore non richiede obbligatoriamente credenziali Spotify.
* Se `SPOTIFY_CLIENT_ID` e `SPOTIFY_CLIENT_SECRET` sono configurati e l’app Spotify ha accesso alla Web API, il sistema prova a recuperare automaticamente metadati completi della traccia.
* Se le credenziali non sono presenti o l’accesso alla Web API non è disponibile, il sistema usa un fallback tramite Spotify oEmbed e permette comunque la compilazione manuale del form.
* Le credenziali sensibili non vengono salvate nel repository: `.env` è escluso da Git, mentre `.env.example` documenta solo le variabili configurabili.
* La cancellazione delle tracce è protetta: una traccia già collegata alla cronologia degli ascolti non viene eliminata, così da preservare l’integrità dei riferimenti.

Closes #19 
